### PR TITLE
create camp modal with confirmation

### DIFF
--- a/public/scripts/camps.js
+++ b/public/scripts/camps.js
@@ -241,7 +241,7 @@ $('#camp_edit_unpublish').click(function() {
  */
 $('#camp_create_save').click(function() {
     var camp_data = {
-        camp_name_he: $('#create_camp_name_he').val() || 'just another camp',
+        camp_name_he: $('#create_camp_name_he').val() || 'camp' + (+ new Date()),
         camp_name_en: $('#create_camp_name_en').val(),
         camp_desc_he: $('#create_camp_desc_he').val(),
         camp_desc_en: $('#create_camp_desc_en').val(),
@@ -276,12 +276,12 @@ $('#camp_create_save').click(function() {
             data: camp_data,
             success: function(result) {
                 var camp_id = result.data.camp_id;
-                $('#create_camp_request_modal').find('.modal-body').html('<h4>Camp created succesfully. <br>you can edit it here: /camps/' + camp_id + '/edit</h4>');
+                $('#create_camp_request_modal').find('.modal-body').html('<h4>Camp created succesfully. <br><span class="Btn Btn__sm Btn__inline">you can edit it: <a href=' + $('body').attr('lang') + '/camps/' + camp_id + '/edit>here</a><span></h4>');
                 $('#create_camp_request_modal').find('#camp_create_save_modal_request').hide();
                 // 5 sec countdown to close modal
                 var sec = 5;
                 setInterval(function() {
-                  $('#create_camp_request_modal').find('#create_camp_close_btn').text('Close ' + sec);
+                    $('#create_camp_request_modal').find('#create_camp_close_btn').text('Close ' + sec);
                     sec -= 1;
                 }, 1000);
                 setTimeout(function() {

--- a/public/scripts/camps.js
+++ b/public/scripts/camps.js
@@ -120,7 +120,9 @@ function innerHeightChange() {
         'min-height': card_height + 'px'
     });
 }
-innerHeightChange();
+$(function() {
+    innerHeightChange();
+});
 // Camp details card transition
 $('.card-switcher--card2').click(function() {
     // show card-2 ; hide card-1
@@ -235,11 +237,11 @@ $('#camp_edit_unpublish').click(function() {
 });
 
 /**
- * Component: Create new camp
+ * Component: Create new camp with approval modal
  */
 $('#camp_create_save').click(function() {
     var camp_data = {
-        camp_name_he: $('#create_camp_name_he').val(),
+        camp_name_he: $('#create_camp_name_he').val() || 'just another camp',
         camp_name_en: $('#create_camp_name_en').val(),
         camp_desc_he: $('#create_camp_desc_he').val(),
         camp_desc_en: $('#create_camp_desc_en').val(),
@@ -253,14 +255,41 @@ $('#camp_create_save').click(function() {
         public_activity_area_sqm: $('#create_public_activity_area_sqm').val(),
         public_activity_area_desc: $('#create_public_activity_area_desc').val()
     };
-    $.ajax({
-        url: '/camps/new',
-        type: 'POST',
-        data: camp_data,
-        success: function(result) {
-            console.log(result);
-        }
+    // show modal & present details in modal
+    $('#create_camp_request_modal').modal('show');
+    $('.camp_details').html(_campDataAsAList());
+    // approve create camp
+    $('#camp_create_save_modal_request').click(function() {
+        _sendRequest();
     });
+    function _campDataAsAList() {
+        var _list = '';
+        $.each(camp_data, function(label, data) {
+            _list += '<li>' + label + ': <b>' + data + '</b></li>';
+        })
+        return $('<ul>').html(_list);
+    }
+    function _sendRequest() {
+        $.ajax({
+            url: '/camps/new',
+            type: 'POST',
+            data: camp_data,
+            success: function(result) {
+                var camp_id = result.data.camp_id;
+                $('#create_camp_request_modal').find('.modal-body').html('<h4>Camp created succesfully. <br>you can edit it here: /camps/' + camp_id + '/edit</h4>');
+                $('#create_camp_request_modal').find('#camp_create_save_modal_request').hide();
+                // 5 sec countdown to close modal
+                var sec = 5;
+                setInterval(function() {
+                  $('#create_camp_request_modal').find('#create_camp_close_btn').text('Close ' + sec);
+                    sec -= 1;
+                }, 1000);
+                setTimeout(function() {
+                    $('#create_camp_request_modal').modal('hide');
+                }, 5000);
+            }
+        });
+    }
 });
 /**
  * Component: join a camp

--- a/routes/api_camps_routes.js
+++ b/routes/api_camps_routes.js
@@ -45,7 +45,8 @@ module.exports = function(app, passport) {
             res.json({
                 error: false,
                 data: {
-                    message: 'camp created'
+                    message: 'camp created',
+                    camp_id: camp.attributes.id
                 }
             });
             CampDetails.forge({

--- a/views/pages/camps/new.jade
+++ b/views/pages/camps/new.jade
@@ -1,122 +1,137 @@
 extends ../../includes/page
 block content
     .camps.camp_create.row
-            .heading.card.card__shad.row
-                .col-md-12
-                    h2=t('camps:new.header_title')
-                    h4=t('camps:new.header_desc')
-            .controls.row
-                .col-xs-12
-                    //- Card switcher
-                    button.Btn.Btn__default.card-switcher--card1 Basic Information
-                    button.Btn.Btn__transparent.card-switcher--card2 Camp Details
-            .cards--wrapper.card__shad.row
-                //- Card 1
-                .card.card-first
-                    h4 Camp Name & Description
-                    .camp-info.panel
-                        .panel-body
-                            .names.col-md-6
+        .heading.card.card__shad.row
+            .col-md-12
+                h2=t('camps:new.header_title')
+                h4=t('camps:new.header_desc')
+        .controls.row
+            .col-xs-12
+                //- Card switcher
+                button.Btn.Btn__default.card-switcher--card1 Basic Information
+                button.Btn.Btn__transparent.card-switcher--card2 Camp Details
+        .cards--wrapper.card__shad.row
+            //- Card 1
+            .card.card-first
+                h4 Camp Name & Description
+                .camp-info.panel
+                    .panel-body
+                        .names.col-md-6
+                            .col-xs-12
+                                label(for='create_camp_name_he')=t('camps:new.name_he')
+                                input(id='create_camp_name_he', type="text", class="form-control", name="camp_name_he", autofocus="true")
+                            .col-xs-12
+                                label(for='create_camp_name_en')=t('camps:new.name_en')
+                                input(id='create_camp_name_en', type="text", class="form-control", name="camp_name_en", value="#{camp_name_en}", disabled)
+                        .descriptions.col-md-6
+                            .col-xs-12
+                                label(for='create_camp_desc_he')=t('camps:new.desc_he')
+                                input(id='create_camp_desc_he', type="text", class="form-control", name="camp_desc_he")
+                            .col-xs-12
+                                label(for='create_camp_desc_en')=t('camps:new.desc_en')
+                                input(id='create_camp_desc_en', type="text", class="form-control", name="camp_desc_en")
+                h4 Camp Contact Personnel
+                .camp-leaders.panel
+                    .panel-body
+                        .personnel
+                            .col-md-4
                                 .col-xs-12
-                                    label(for='create_camp_name_he')=t('camps:new.name_he')
-                                    input(id='create_camp_name_he', type="text", class="form-control", name="camp_name_he", autofocus="true")
+                                    label(for='create_camp_main_contact')=t('camps:new.main_contact')
+                                    select(id='create_camp_main_contact', class="form-control", name="main_contact")
+                            .col-md-4
                                 .col-xs-12
-                                    label(for='create_camp_name_en')=t('camps:new.name_en')
-                                    input(id='create_camp_name_en', type="text", class="form-control", name="camp_name_en", value="#{camp_name_en}", disabled)
-                            .descriptions.col-md-6
+                                    label(for='create_camp_moop_contact')=t('camps:new.moop_contact')
+                                    select(id='create_camp_moop_contact', class="form-control", name="moop_contact")
+                            .col-md-4
                                 .col-xs-12
-                                    label(for='create_camp_desc_he')=t('camps:new.desc_he')
-                                    input(id='create_camp_desc_he', type="text", class="form-control", name="camp_desc_he")
+                                    label(for='create_camp_safety_contact')=t('camps:new.safety_contact')
+                                    select(id='create_camp_safety_contact', class="form-control", name="safety_contact")
+                h4 Camp Behaviour
+                .camp-leaders.panel
+                    .panel-body
+                        .behaviour
+                            .col-md-4
                                 .col-xs-12
-                                    label(for='create_camp_desc_en')=t('camps:new.desc_en')
-                                    input(id='create_camp_desc_en', type="text", class="form-control", name="camp_desc_en")
-                    h4 Camp Contact Personnel
-                    .camp-leaders.panel
-                        .panel-body
-                            .personnel
-                                .col-md-4
-                                    .col-xs-12
-                                        label(for='create_camp_main_contact')=t('camps:new.main_contact')
-                                        select(id='create_camp_main_contact', class="form-control", name="main_contact")
-                                .col-md-4
-                                    .col-xs-12
-                                        label(for='create_camp_moop_contact')=t('camps:new.moop_contact')
-                                        select(id='create_camp_moop_contact', class="form-control", name="moop_contact")
-                                .col-md-4
-                                    .col-xs-12
-                                        label(for='create_camp_safety_contact')=t('camps:new.safety_contact')
-                                        select(id='create_camp_safety_contact', class="form-control", name="safety_contact")
-                    h4 Camp Behaviour
-                    .camp-leaders.panel
-                        .panel-body
-                            .behaviour
-                                .col-md-4
-                                    .col-xs-12
-                                        label(for='create_camp_type')=t('camps:new.camp_type')
-                                        input(id='create_camp_type', type="text", class="form-control", name="type")
-                //- Card 2
-                .card.card-second.card-hide
-                    h4 Camp Behaviour
-                    .camp-details.panel
-                        .panel-body
-                            .camp-behavior
-                                .col-md-4
-                                    .col-xs-12
-                                        label(for='create_camp_activity_time')=t('camps:new.camp_activity_time')
-                                        select(id='create_camp_activity_time', class="form-control", name="camp_activity_time")
-                                            option(value="morning") morning
-                                            option(value="noon") noon
-                                            option(value="evening") evening
-                                            option(value="night") night
-                                .col-md-4
-                                    .col-xs-12
-                                        label(for='create_camp_child_friendly')=t('camps:new.camp_child_friendly')
-                                        input(id='create_camp_child_friendly', type="text", class="form-control", name="child_friendly")
-                                .col-md-4
-                                    .col-xs-12
-                                        label(for='create_camp_noise_level')=t('camps:new.camp_noise_level')
-                                        select(id='create_camp_noise_level', class="form-control", name="noise_level")
-                                            option(value="quiet") quiet
-                                            option(value="medium") medium
-                                            option(value="noisy") noisy
-                                            option(value="very noisy") very noisy
-                    h4 Camp Public Area
-                    .camp-details.panel
-                        .panel-body
-                            .camp-public
-                                .col-md-4
-                                    .col-xs-12
-                                        label(for='create_camp_public_activity_area_sqm')=t('camps:new.public_activity_area_sqm')
-                                        input(id='create_camp_public_activity_area_sqm', type="number",min="1",class="form-control", name="public_activity_area_sqm")
-                                .col-md-4
-                                    .col-xs-12
-                                        label(for='create_camp_public_area_reason')=t('camps:new.public_activity_area_desc')
-                                        input(id='create_camp_public_area_reason', type="text", class="form-control", name="public_activity_area_desc")
-                                .col-md-4
-                                    .col-xs-12
-                                        label(for='create_support_art')=t('camps:new.support_art')
-                                        input.form-control(id='create_support_art', type="text", name='support_art')
-                    h4 Camp Location
-                    .camp-details.panel
-                        .panel-body
-                            .camp-location
-                                .col-md-4
-                                    .col-xs-12
-                                        label(for='create_location_comments')=t('camps:new.location_comments')
-                                        input.form-control(id='create_location_comments', name='location_comments')
-                                .col-md-4
-                                    .col-xs-12
-                                        label(for='create_camp_location_street')=t('camps:new.camp_location_street')
-                                        input.form-control(id='create_camp_location_street', name='camp_location_street')
-                                .col-md-4
-                                    .col-xs-12
-                                        label(for='create_camp_location_street_time')=t('camps:new.camp_location_street_time')
-                                        input.form-control(id='create_camp_location_street_time', name='camp_location_street_time')
-                                .col-md-4
-                                    .col-xs-12
-                                        label(for='create_camp_location_area')=t('camps:new.camp_location_area')
-                                        input.form-control(id='create_camp_location_area', name='camp_location_area')
+                                    label(for='create_camp_type')=t('camps:new.camp_type')
+                                    input(id='create_camp_type', type="text", class="form-control", name="type")
+            //- Card 2
+            .card.card-second.card-hide
+                h4 Camp Behaviour
+                .camp-details.panel
+                    .panel-body
+                        .camp-behavior
+                            .col-md-4
+                                .col-xs-12
+                                    label(for='create_camp_activity_time')=t('camps:new.camp_activity_time')
+                                    select(id='create_camp_activity_time', class="form-control", name="camp_activity_time")
+                                        option(value="morning") morning
+                                        option(value="noon") noon
+                                        option(value="evening") evening
+                                        option(value="night") night
+                            .col-md-4
+                                .col-xs-12
+                                    label(for='create_camp_child_friendly')=t('camps:new.camp_child_friendly')
+                                    input(id='create_camp_child_friendly', type="text", class="form-control", name="child_friendly")
+                            .col-md-4
+                                .col-xs-12
+                                    label(for='create_camp_noise_level')=t('camps:new.camp_noise_level')
+                                    select(id='create_camp_noise_level', class="form-control", name="noise_level")
+                                        option(value="quiet") quiet
+                                        option(value="medium") medium
+                                        option(value="noisy") noisy
+                                        option(value="very noisy") very noisy
+                h4 Camp Public Area
+                .camp-details.panel
+                    .panel-body
+                        .camp-public
+                            .col-md-4
+                                .col-xs-12
+                                    label(for='create_camp_public_activity_area_sqm')=t('camps:new.public_activity_area_sqm')
+                                    input(id='create_camp_public_activity_area_sqm', type="number",min="1",class="form-control", name="public_activity_area_sqm")
+                            .col-md-4
+                                .col-xs-12
+                                    label(for='create_camp_public_area_reason')=t('camps:new.public_activity_area_desc')
+                                    input(id='create_camp_public_area_reason', type="text", class="form-control", name="public_activity_area_desc")
+                            .col-md-4
+                                .col-xs-12
+                                    label(for='create_support_art')=t('camps:new.support_art')
+                                    input.form-control(id='create_support_art', type="text", name='support_art')
+                h4 Camp Location
+                .camp-details.panel
+                    .panel-body
+                        .camp-location
+                            .col-md-4
+                                .col-xs-12
+                                    label(for='create_location_comments')=t('camps:new.location_comments')
+                                    input.form-control(id='create_location_comments', name='location_comments')
+                            .col-md-4
+                                .col-xs-12
+                                    label(for='create_camp_location_street')=t('camps:new.camp_location_street')
+                                    input.form-control(id='create_camp_location_street', name='camp_location_street')
+                            .col-md-4
+                                .col-xs-12
+                                    label(for='create_camp_location_street_time')=t('camps:new.camp_location_street_time')
+                                    input.form-control(id='create_camp_location_street_time', name='camp_location_street_time')
+                            .col-md-4
+                                .col-xs-12
+                                    label(for='create_camp_location_area')=t('camps:new.camp_location_area')
+                                    input.form-control(id='create_camp_location_area', name='camp_location_area')
 
-            .controls.row
-                .col-xs-12
-                    button(type="submit", id='camp_create_save', class="Btn Btn__default")=t('camps:btn_save_camp')
+        .controls.row
+            .col-xs-12
+                button(type="submit", id='camp_create_save', class="Btn Btn__default")=t('camps:btn_save_camp')
+
+        // Camp create request modal
+        .modal.fade(id='create_camp_request_modal', tabindex='-1', role='dialog')
+            .modal-dialog.card.card__even-pad.card__shad(role='document')
+                div
+                    .modal-header
+                        button.close(type='button', data-dismiss='modal', aria-label='Close')
+                            span(aria-hidden='true') ×
+                        h4.modal-title Create a camp request
+                    .modal-body
+                        p The request of creating new camp will be sent with these details
+                        .camp_details
+                    .modal-footer
+                        button.Btn.Btn__transparent(id='create_camp_close_btn', type='button', data-dismiss='modal') Close
+                        button.Btn.Btn__green(id='camp_create_save_modal_request', type='button') Send Request


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->

### Proposed solution
cool  confirmation modal with auto close after camp created.

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->


### Testing Done
<!-- How have you confirmed this feature works? -->

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Spark dependencies -->
<!-- 3. Make sure your code is compliant with the [Spark styleguide](CONTRIBUTING.md) -->
<!-- 4. If your PR fixes an issue, reference that issue -->
<!-- 5. If your PR has lots of commits, **rebase** first -->
<!-- 6. Run `npm test` before submitting your PR -->
