### PR TITLE
fix issue #106: language selector

### DIFF
--- a/views/includes/page.jade
+++ b/views/includes/page.jade
@@ -27,12 +27,12 @@ block wrapper
                             span.caret
                         ul.dropdown-menu
                             li
-                                a( href="/he#{req.url.substr(3)}" )
+                                a( href="/he#{req.originalUrl.substr(3)}" )
                                     img( src="/images/flags/he.gif" )
                                     |&nbsp;
                                     span=t('hebrew')
                             li
-                                a( href="/en#{req.url.substr(3)}" )
+                                a( href="/en#{req.originalUrl.substr(3)}" )
                                     img( src="/images/flags/en.gif" )
                                     |&nbsp;
                                     span=t('english')


### PR DESCRIPTION
### Issue and root cause
Under the /npo route, using the language selector doesn't switch languages but loads the login page instead.

The problem was caused by using req.url in page.jade view for building the redirection path, which returns the path relative to '/npo' due to the usage of express.Router() instead of full path like in routings made with app.* methods.

### Proposed solution
Inside the view, using req.originalUrl returns the same path for both app.* and express.Router() routes.
