### PR TITLE
fix mismatched variable names

### DIFF
--- a/routes/api_camps_routes.js
+++ b/routes/api_camps_routes.js
@@ -72,7 +72,7 @@ module.exports = function(app, passport) {
                 res.status(500).json({
                     error: true,
                     data: {
-                        message: err.message
+                        message: e.message
                     }
                 });
             })


### PR DESCRIPTION
### Issue found
A mismatch between variable names causing unhandled exception was found: `catch(e)` vs. the use of `err.message`. To reproduce, create a new camp from the browser.

### Proposed solution
Changing `err.message` to `e.message` solves the issue.

