### PR TITLE
Camps relation db

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ node_js:
   - "7"
 cache:
   directories:
-    - node_modules
     - bower_components
 script:
   - yarn add bower

--- a/migrations/20170314162251_camps_relation_db.js
+++ b/migrations/20170314162251_camps_relation_db.js
@@ -1,40 +1,61 @@
 var constants = require('../models/constants.js');
 
-exports.up = function(knex, Promise) {
+exports.up = function (knex, Promise) {
     return Promise.all([
-        knex.schema.alterTable(constants.CAMPS_TABLE_NAME,function(table) {
-            table.string('event_id',15);
-            table.dropUnique('camp_name_he');
-            table.dropUnique('camp_name_en');
-            table.unique(['event_id','camp_name_en']);
-            table.unique(['event_id','camp_name_he']);
-        }),
-        knex.schema.alterTable(constants.CAMP_DETAILS_TABLE_NAME,function(table) {
-            table.unique(['camp_id']);
+        knex.schema.alterTable(constants.CAMPS_TABLE_NAME, function (table) {
+            if (!knex.schema.hasColumn(constants.CAMPS_TABLE_NAME, 'event_id')) {
+                table.string('event_id', 15);
+                table.dropUnique('camp_name_he');
+                table.dropUnique('camp_name_en');
+                table.unique(['event_id', 'camp_name_en']);
+                table.unique(['event_id', 'camp_name_he']);
+            }
+
+            // Detailed info
+            table.enu('camp_activity_time', constants.CAMP_ACTIVITY_TIMES);
+            table.boolean('child_friendly');
+            table.enu('noise_level', constants.CAMP_NOISE_LEVELS);
+            table.integer('public_activity_area_sqm');
+            table.text('public_activity_area_desc', 'mediumtext');
+            table.boolean('support_art');
+
+            // Location
+            table.text('location_comments', 'mediumtext');
+            table.text('camp_location_street');
+            table.text('camp_location_street_time');
+            table.integer('camp_location_area');
+
+            // Contact person info on top id
+            table.string('contact_person_name', 100);
+            table.string('contact_person_email', 100);
+            table.string('contact_person_phone', 14);
+
         }),
         knex.schema.createTable(constants.CAMP_MEMBERS_TABLE_NAME, function (table) {
-            // table.string('event_id',15);
             table.integer('camp_id').unsigned();
             table.integer('user_id').unsigned();
             table.unique(['user_id']);
             table.index('camp_id');
-            table.foreign('camp_id').references(constants.CAMPS_TABLE_NAME+'.id');
-            table.foreign('user_id').references(constants.USERS_TABLE_NAME+'.user_id');
-            table.enu('status',constants.CAMP_MEMBER_STATUS);
-            table.text('addinfo_json','mediumtext');
+            table.foreign('camp_id').references(constants.CAMPS_TABLE_NAME + '.id');
+            table.foreign('user_id').references(constants.USERS_TABLE_NAME + '.user_id');
+            table.enu('status', constants.CAMP_MEMBER_STATUS);
+            table.text('addinfo_json', 'mediumtext');
         }),
-        knex.schema.alterTable(constants.CAMP_DETAILS_TABLE_NAME,function(table) {
-            table.unique('camp_id');
-            table.foreign('camp_id').references(constants.CAMPS_TABLE_NAME+'.id');
-        }),
-        knex.schema.createTable('props',function(table) {
-            table.string('prop_id',50);
-            table.string('group_id',50);
+
+        knex.schema.createTable('props', function (table) {
+            table.string('prop_id', 50);
+            table.string('group_id', 50);
             table.text('data_json');
-            table.unique(['group_id','prop_id']);
+            table.unique(['group_id', 'prop_id']);
             table.index('prop_id');
         })
     ]);
 };
 
-exports.down = function(knex, Promise) {};
+exports.down = function (knex, Promise) {
+    return Promise.all([
+        knex.schema.dropTable('props'),
+        knex.schema.dropTable(constants.CAMP_MEMBERS_TABLE_NAME),
+    ]);
+};
+

--- a/migrations/20170314162251_camps_relation_db.js
+++ b/migrations/20170314162251_camps_relation_db.js
@@ -1,0 +1,40 @@
+var constants = require('../models/constants.js');
+
+exports.up = function(knex, Promise) {
+    return Promise.all([
+        knex.schema.alterTable(constants.CAMPS_TABLE_NAME,function(table) {
+            table.string('event_id',15);
+            table.dropUnique('camp_name_he');
+            table.dropUnique('camp_name_en');
+            table.unique(['event_id','camp_name_en']);
+            table.unique(['event_id','camp_name_he']);
+        }),
+        knex.schema.alterTable(constants.CAMP_DETAILS_TABLE_NAME,function(table) {
+            table.unique(['camp_id']);
+        }),
+        knex.schema.createTable(constants.CAMP_MEMBERS_TABLE_NAME, function (table) {
+            // table.string('event_id',15);
+            table.integer('camp_id').unsigned();
+            table.integer('user_id').unsigned();
+            table.unique(['user_id']);
+            table.index('camp_id');
+            table.foreign('camp_id').references(constants.CAMPS_TABLE_NAME+'.id');
+            table.foreign('user_id').references(constants.USERS_TABLE_NAME+'.user_id');
+            table.enu('status',constants.CAMP_MEMBER_STATUS);
+            table.text('addinfo_json','mediumtext');
+        }),
+        knex.schema.alterTable(constants.CAMP_DETAILS_TABLE_NAME,function(table) {
+            table.unique('camp_id');
+            table.foreign('camp_id').references(constants.CAMPS_TABLE_NAME+'.id');
+        }),
+        knex.schema.createTable('props',function(table) {
+            table.string('prop_id',50);
+            table.string('group_id',50);
+            table.text('data_json');
+            table.unique(['group_id','prop_id']);
+            table.index('prop_id');
+        })
+    ]);
+};
+
+exports.down = function(knex, Promise) {};


### PR DESCRIPTION

@asihud 

Tried to migrate this and throw an error:

notice build log from travis [here](https://travis-ci.org/Midburn/Spark/builds/213014690)

```
Knex:warning - SQLite3 Foreign & Primary keys may only be added on create
Knex:warning - migrations failed with error: Cannot read property 'replace' of undefined
TypeError: Cannot read property 'replace' of undefined
    at TableCompiler._indexCommand (/home/nate/dev/spark/node_modules/knex/lib/schema/tablecompiler.js:213:24)
    at TableCompiler_SQLite3.unique (/home/nate/dev/spark/node_modules/knex/lib/dialects/sqlite3/schema/tablecompiler.js:69:65)
    at TableCompiler.alterTable (/home/nate/dev/spark/node_modules/knex/lib/schema/tablecompiler.js:154:30)
    at TableCompiler.create (/home/nate/dev/spark/node_modules/knex/lib/schema/tablecompiler.js:59:8)
    at TableCompiler.toSQL (/home/nate/dev/spark/node_modules/knex/lib/schema/tablecompiler.js:37:20)
    at TableBuilder.toSQL (/home/nate/dev/spark/node_modules/knex/lib/schema/tablebuilder.js:48:42)
    at SchemaCompiler.createTable (/home/nate/dev/spark/node_modules/knex/lib/schema/compiler.js:62:23)
    at SchemaCompiler.toSQL (/home/nate/dev/spark/node_modules/knex/lib/schema/compiler.js:50:26)
    at SchemaBuilder.toSQL (/home/nate/dev/spark/node_modules/knex/lib/schema/builder.js:51:43)
    at /home/nate/dev/spark/node_modules/knex/lib/runner.js:46:32
    at tryCatcher (/home/nate/dev/spark/node_modules/bluebird/js/release/util.js:16:23)
    at /home/nate/dev/spark/node_modules/bluebird/js/release/using.js:185:26
    at tryCatcher (/home/nate/dev/spark/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/home/nate/dev/spark/node_modules/bluebird/js/release/promise.js:510:31)
    at Promise._settlePromise (/home/nate/dev/spark/node_modules/bluebird/js/release/promise.js:567:18)
    at Promise._settlePromise0 (/home/nate/dev/spark/node_modules/bluebird/js/release/promise.js:612:10)
    at Promise._settlePromises (/home/nate/dev/spark/node_modules/bluebird/js/release/promise.js:691:18)
    at Promise._fulfill (/home/nate/dev/spark/node_modules/bluebird/js/release/promise.js:636:18)
    at PromiseArray._resolve (/home/nate/dev/spark/node_modules/bluebird/js/release/promise_array.js:125:19)
    at PromiseArray._promiseFulfilled (/home/nate/dev/spark/node_modules/bluebird/js/release/promise_array.js:143:14)
    at Promise._settlePromise (/home/nate/dev/spark/node_modules/bluebird/js/release/promise.js:572:26)
    at Promise._settlePromise0 (/home/nate/dev/spark/node_modules/bluebird/js/release/promise.js:612:10)
```