### PR TITLE
fix selector to populate table

### DIFF
--- a/public/scripts/camps.js
+++ b/public/scripts/camps.js
@@ -90,7 +90,7 @@ $(function() {
  * getting camp list from API
  */
 var fetchedCampsOnce = false,
-    $stats_table = $('.camps.stats .table');
+    $stats_table = $('.camps.camp_admin_index .table');
 
 function getCampsTemplate(data) {
     var last_update = new Date(data.updated_at).toDateString(),


### PR DESCRIPTION
### Proposed solution
The 'Manage Camps' table wasn't populated by JS due to wrong css selector.
Fixed.

### Testing Done
Passes tests