### PR TITLE
Fix create-admin route

### DIFF
--- a/routes/dev_routes.js
+++ b/routes/dev_routes.js
@@ -21,10 +21,10 @@ router.get('/create-admin', function (req, res) {
     newUser.generateHash('a');
 
     newUser.save().then(function (model) {
-        res.redirect("/");
+        res.send('User a, password a successfully written. Go to / and login');
+    }).catch(function () {
+        res.status(500).send("Error creating dev user, check logs");
     });
-
-    res.redirect("./");
 });
 
 router.get('/view-debug/*', function (req, res) {


### PR DESCRIPTION
`/dev/create-admin` is faulty, tries to do `res.redirect` twice, both inside and outside the promise, causing the following error, which this PR fixes:

```
        {"isFulfilled":false,"isRejected":true,"rejectionReason":{"message":"Can't set headers after they are sent.","stack":"Error: Can't set headers after they are sent.
    at ServerResponse.setHeader (_http_outgoing.js:367:11)
    at ServerResponse.header (C:\\work\\midburn\\Spark\\node_modules\\express\\lib\\response.js:718:10)
    at ServerResponse.location (C:\\work\\midburn\\Spark\\node_modules\\express\\lib\\response.js:835:8)
    at ServerResponse.redirect (C:\\work\\midburn\\Spark\\node_modules\\express\\lib\\response.js:874:8)
    at Child.<anonymous> (C:\\work\\midburn\\Spark\\routes\\dev_routes.js:24:13)
    at Child.tryCatcher (C:\\work\\midburn\\Spark\\node_modules\\bookshelf\\node_modules\\bluebird\\js\\release\\util.js:16:23)
    at Promise._settlePromiseFromHandler (C:\\work\\midburn\\Spark\\node_modules\\bookshelf\\node_modules\\bluebird\\js\\release\\promise.js:510:31)
    at Promise._settlePromise (C:\\work\\midburn\\Spark\\node_modules\\bookshelf\\node_modules\\bluebird\\js\\release\\promise.js:567:18)
    at Promise._settlePromise0 (C:\\work\\midburn\\Spark\\node_modules\\bookshelf\\node_modules\\bluebird\\js\\release\\promise.js:612:10)
    at Promise._settlePromises (C:\\work\\midburn\\Spark\\node_modules\\bookshelf\\node_modules\\bluebird\\js\\release\\promise.js:691:18)
    at Async._drainQueue (C:\\work\\midburn\\Spark\\node_modules\\bookshelf\\node_modules\\bluebird\\js\\release\\async.js:133:16)
    at Async._drainQueues (C:\\work\\midburn\\Spark\\node_modules\\bookshelf\\node_modules\\bluebird\\js\\release\\async.js:143:10)
    at Immediate.Async.drainQueues (C:\\work\\midburn\\Spark\\node_modules\\bookshelf\\node_modules\\bluebird\\js\\release\\async.js:17:14)
    at runCallback (timers.js:651:20)
    at tryOnImmediate (timers.js:624:5)
    at processImmediate [as _immediateCallback] (timers.js:596:5)"}}
```