### PR TITLE
Added support for running tests on a dedicated database 

### DIFF
--- a/migrations/create_test_db.sql
+++ b/migrations/create_test_db.sql
@@ -1,0 +1,16 @@
+DROP DATABASE IF EXISTS spark_test;
+
+# Implicitly create the user and then drop the user.
+GRANT USAGE ON *.* TO 'spark'@'%' IDENTIFIED BY 'password';
+DROP USER 'spark'@'%';
+flush privileges;
+
+CREATE DATABASE IF NOT EXISTS spark_test;
+
+ALTER DATABASE spark_test CHARACTER SET utf8;
+ALTER DATABASE spark_test COLLATE utf8_general_ci;
+
+CREATE USER 'spark'@'%'
+  IDENTIFIED BY 'spark';
+
+GRANT ALL ON spark_test.* TO 'spark'@'%';

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
         "postinstall": "bower install",
         "start": "node server.js",
         "pretest": "npm run lint",
-        "test": "cross-env npm run testcore",
-        "testcore": "rimraf test.sqlite3 && mocha \"tests/**/*test.js\" ",
+        "test": "npm run testcore",
+        "testcore": "npm run create_test_db  && cross-env SPARK_DB_DBNAME=spark_test mocha \"tests/**/*test.js\" ",
         "//devops": "Generic deployment / devops commands, used from .travis.yml, see /docs/development/releases-and-deployment.md",
         "//log": "send a generic log notification to slack",
         "log": "curl -X POST -g $npm_config_webhook --data-urlencode 'payload={\"channel\": \"'\"#${npm_config_channel:-sparksystem-log}\"'\", \"username\": \"'\"${npm_config_username:-bot}\"'\", \"text\": \"'\"${npm_config_text}\"'\", \"icon_emoji\": \"'\"${npm_config_emoji:-ghost}\"'\"}'",
@@ -27,7 +27,8 @@
         "//lint": "runs static analysis using eslint",
         "lint": "./node_modules/.bin/eslint .",
         "//createdb": "bootstraps MySql with a clean spark database & user",
-        "createdb": "mysql -u root < migrations/create_db.sql"
+        "createdb": "mysql -u root < migrations/create_db.sql",
+        "create_test_db": "cross-env SPARK_DB_DBNAME=spark_test mysql -u root --protocol=tcp < migrations/create_test_db.sql && cross-env SPARK_DB_DBNAME=spark_test knex migrate:latest"
     },
     "dependencies": {
         "async": "^2.1.4",

--- a/tests/routes/main_routes.test.js
+++ b/tests/routes/main_routes.test.js
@@ -8,6 +8,7 @@ var User = require('../../models/user').User;
 var knex = require('../../libs/db').knex;
 
 describe('Main routes', function() {
+    this.timeout(5000);
     it('responds to / with redirect to hebrew', function testSlash(done) {
         request
             .get('/')


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
Fixes #351 
### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
Copied the createdb script to and modified it to create a spark_test database.
Now the test execution is performed in steps:  
1 - create spark_test db
2 - run migrations
3 - run tests
### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->
In the new create_test_db script the `spark@'%'` user is created instead of `spark@localhost`. I'm running mysql inside docker so I found no other way to make it work.

### Testing Done
<!-- How have you confirmed this feature works? -->
Test and migrations pass.
<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Spark dependencies -->
<!-- 3. Make sure your code is compliant with the [Spark styleguide](CONTRIBUTING.md) -->
<!-- 4. If your PR fixes an issue, reference that issue -->
<!-- 5. If your PR has lots of commits, **rebase** first -->
<!-- 6. Run `npm test` before submitting your PR -->
