### PR TITLE
added cache to drupal search

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -126,4 +126,5 @@ exports.profiles_api = {
     username: process.env.DRUPAL_PROFILE_API_USER || 'dummy',
     password: process.env.DRUPAL_PROFILE_API_PASSWORD || 'dummy',
     useCache: process.env.USE_DRUPAL_CACHE || false,
+    cacheTTL: process.env.USE_DRUPAL_CACHE_TTL || 3600*24,
 };

--- a/config/default.js
+++ b/config/default.js
@@ -124,5 +124,6 @@ exports.api_tokens = {
 exports.profiles_api = {
     url: process.env.DRUPAL_PROFILE_API_URL || 'http://dummy.url',
     username: process.env.DRUPAL_PROFILE_API_USER || 'dummy',
-    password: process.env.DRUPAL_PROFILE_API_PASSWORD || 'dummy'
+    password: process.env.DRUPAL_PROFILE_API_PASSWORD || 'dummy',
+    useCache: process.env.USE_DRUPAL_CACHE || false,
 };

--- a/libs/drupal_access.js
+++ b/libs/drupal_access.js
@@ -3,7 +3,8 @@ const request = require('superagent');
 const logger = require('../libs/logger')(module);
 const drupalConfig = require('config').get('profiles_api');
 const NodeCache = require("node-cache");
-const drupalCache = new NodeCache({ stdTTL: 60*60*24, checkperiod: 600 });
+
+const drupalCache = new NodeCache({ stdTTL: drupalConfig.cacheTTL, checkperiod: 600 });
 
 function parseFromAnchorTag(uid_string) {
     var re = /<a.*>(.+)<\/a>/g;

--- a/libs/drupal_access.js
+++ b/libs/drupal_access.js
@@ -1,7 +1,9 @@
 require('dotenv').config()
-var request = require('superagent');
-var logger = require('../libs/logger')(module);
-var drupalConfig = require('config').get('profiles_api');
+const request = require('superagent');
+const logger = require('../libs/logger')(module);
+const drupalConfig = require('config').get('profiles_api');
+const NodeCache = require("node-cache");
+const drupalCache = new NodeCache({ stdTTL: 60*60*24, checkperiod: 600 });
 
 function parseFromAnchorTag(uid_string) {
     var re = /<a.*>(.+)<\/a>/g;
@@ -74,17 +76,25 @@ var search_multiple_emails = function(login_data, email_arr) {
 var search = function(login_data, email, uid, is_retry) {
     return new Promise((resolve, reject) => {
         var qs = {};
+        var key;
         if (email) {
-            qs.mail = email
+            qs.mail = email;
+            key = email;
         }
         if (uid) {
-            qs.uid = uid
+            qs.uid = uid;
+            key = uid;
+        }
+        var user_data_ = drupalCache.get(key)
+        if (user_data_ && drupalConfig.useCache) {
+            return resolve({ email: qs.mail, uid: qs.uid, user_data: user_data_ });
         }
         login_data.request_agent
             .get(drupalConfig.url + '/en/api/usersearch')
             .query(qs)
             .then((res) => {
-                var user_data_ = parseUser(res.body)
+                user_data_ = parseUser(res.body)
+                drupalCache.set(key, user_data_);
                 resolve({ email: qs.mail, uid: qs.uid, user_data: user_data_ });
             }).catch((err) => {
                 if (err.status === 403 && !is_retry) {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "module-id": "2.0.4",
     "morgan": "~1.7.0",
     "mysql": "^2.11.1",
+    "node-cache": "^4.1.1",
     "node-sass": "^3.13.0",
     "passport": "^0.3.2",
     "passport-facebook": "2.1.1",


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
Drupal cannot handle the search request that come from volunteers module through spark. 
It was decided to cache drupal searches in spark.
### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
userdata is stored in memory with TTL of one day.

`USE_DRUPAL_CACHE=true` env vairable enables the cache usage.

node-cache package is used.
### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

drupal changes will be reflected only after cache invalidation
### Testing Done
<!-- How have you confirmed this feature works? -->

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Spark dependencies -->
<!-- 3. Make sure your code is compliant with the [Spark styleguide](CONTRIBUTING.md) -->
<!-- 4. If your PR fixes an issue, reference that issue -->
<!-- 5. If your PR has lots of commits, **rebase** first -->
<!-- 6. Run `npm test` before submitting your PR -->
