### PR TITLE
Pre sale tickets

### DIFF
--- a/locales/en/camps.json
+++ b/locales/en/camps.json
@@ -91,6 +91,7 @@
         "location_card_title": "Camp location",
         "location_comments": "Comments",
         "early_arrival_quota": "Early Arrival Quota",
+        "pre_sale_ticket_quota": "Pre Sale Quota",
         "camp_location_street": "Street",
         "camp_location_street_time": "Street time",
         "camp_location_area": "Area",
@@ -164,6 +165,7 @@
         "status_rejected": "Camp manager did not approve request",
         "status_pending_mgr": "Waiting for member acceptance",
         "inside_event": "Inside Event",
+        "pre_sale_ticket_approved": "Pre Sale Ticket Approved",
         "status_approved_mgr": "Approved as Manager",
         "status_supplier": "Supplier"
     },

--- a/locales/en/camps.json
+++ b/locales/en/camps.json
@@ -91,6 +91,8 @@
         "location_card_title": "Camp location",
         "location_comments": "Comments",
         "early_arrival_quota": "Early Arrival Quota",
+        "pre_sale_ticket_quota": "Pre-Sale Tickets Quota",
+        "pre_sale_ticket_count": "Pre-Sale Tickets Count",
         "camp_location_street": "Street",
         "camp_location_street_time": "Street time",
         "camp_location_area": "Area",
@@ -164,6 +166,8 @@
         "status_rejected": "Camp manager did not approve request",
         "status_pending_mgr": "Waiting for member acceptance",
         "inside_event": "Inside Event",
+        "pre_sale_ticket_approved": "Approve Pre-sale Ticket",
+        "pre_sale_ticket_remove": "Remove Pre-sale Ticket",
         "status_approved_mgr": "Approved as Manager",
         "status_supplier": "Supplier"
     },

--- a/locales/he/camps.json
+++ b/locales/he/camps.json
@@ -137,7 +137,9 @@
         "facebook_page_url": "דף פייסבוק",
         "remove": "הסרה",
         "search": "חפש מחנה",
-        "entrance_quota": "מכסת הגעה מוקדמת"
+        "entrance_quota": "מכסת הגעה מוקדמת",
+        "pre_sale_ticket_quota": "מכסת מכירה מוקדמת",
+        "pre_sale_ticket_count": "סה״כ כרטיסים במכירה מוקדמת"
     },
     "members": {
         "title": "משתתפים במחנה",
@@ -164,6 +166,8 @@
         "status_pending_mgr": "ממתין לאישור החברה המצטרפת",
         "status_approved_mgr": "מנהלת מחנה מאושרת",
         "inside_event": "בתוך האירוע",
+        "pre_sale_ticket_approved": "אשר כרטיס במכירה מוקדמת",
+        "pre_sale_ticket_remove": "הסר כרטיס ממכירה מוקדמת",
         "status_supplier": "מאושר כספק"
     },
     "camps": {
@@ -255,6 +259,8 @@
         "contact_person_email": "אימייל איש קשר",
         "contact_person_phone": "טלפון אישר קשר",
         "early_arrival_quota": "כמות מגיעים מוקדם",
+        "pre_sale_ticket_quota": "מכסת כרטיסים במכירה מוקדמת",
+        "pre_sale_ticket_count": "סה״כ כרטיסים במכירה מוקדמת",
         "security_file": "תיק בטיחות",
         "members_header": "נהל חברי מחנה",
         "search_member": "מצא חבר מחנה"

--- a/locales/he/camps.json
+++ b/locales/he/camps.json
@@ -137,7 +137,8 @@
         "facebook_page_url": "דף פייסבוק",
         "remove": "הסרה",
         "search": "חפש מחנה",
-        "entrance_quota": "מכסת הגעה מוקדמת"
+        "entrance_quota": "מכסת הגעה מוקדמת",
+        "pre_sale_ticket_quota": "מכסת מכירה מוקדמת"
     },
     "members": {
         "title": "משתתפים במחנה",
@@ -164,6 +165,7 @@
         "status_pending_mgr": "ממתין לאישור החברה המצטרפת",
         "status_approved_mgr": "מנהלת מחנה מאושרת",
         "inside_event": "בתוך האירוע",
+        "pre_sale_ticket_approved": "מכירת כרטיס מוקדמת מאושרת",
         "status_supplier": "מאושר כספק"
     },
     "camps": {
@@ -255,6 +257,7 @@
         "contact_person_email": "אימייל איש קשר",
         "contact_person_phone": "טלפון אישר קשר",
         "early_arrival_quota": "כמות מגיעים מוקדם",
+        "pre_sale_ticket_quota": "מכסת כרטיסים במכירה מוקדמת",
         "security_file": "תיק בטיחות",
         "members_header": "נהל חברי מחנה",
         "search_member": "מצא חבר מחנה"

--- a/migrations/20170427182849_gate_data.js
+++ b/migrations/20170427182849_gate_data.js
@@ -12,7 +12,7 @@ exports.up = function (knex, Promise) {
         }),
 
         knex('events').insert({
-            event_id: "MIDBURN2018",
+            event_id: "MIDBURN2017",
             gate_code: "171819",
             name: "Midburn 2017 מידברן",
             gate_status: "early_arrival"

--- a/migrations/20170427182849_gate_data.js
+++ b/migrations/20170427182849_gate_data.js
@@ -12,7 +12,7 @@ exports.up = function (knex, Promise) {
         }),
 
         knex('events').insert({
-            event_id: "MIDBURN2017",
+            event_id: "MIDBURN2018",
             gate_code: "171819",
             name: "Midburn 2017 מידברן",
             gate_status: "early_arrival"

--- a/models/camp.js
+++ b/models/camp.js
@@ -34,7 +34,7 @@ var Camp = bookshelf.Model.extend({
 
         // let _camps_members = constants.CAMP_MEMBERS_TABLE_NAME;
         // let _users = constants.USERS_TABLE_NAME;
-        let query = "SELECT users.*,camp_members.status AS member_status,SUM(IF(tickets.ticket_id>0,1,0)) AS ticket_count,SUM(tickets.inside_event) AS inside_event, camp_members.addinfo_json AS camps_members_addinfo_json FROM users INNER JOIN camp_members on users.user_id=camp_members.user_id left join tickets on tickets.holder_id=users.user_id and tickets.event_id='MIDBURN2017' where camp_members.camp_id=" + this.attributes.id + " group by users.user_id";
+        let query = "SELECT users.*,camp_members.status AS member_status,SUM(IF(tickets.ticket_id>0,1,0)) AS ticket_count,SUM(tickets.inside_event) AS inside_event, camp_members.addinfo_json AS camps_members_addinfo_json FROM users INNER JOIN camp_members on users.user_id=camp_members.user_id left join tickets on tickets.holder_id=users.user_id and tickets.event_id='MIDBURN2018' where camp_members.camp_id=" + this.attributes.id + " group by users.user_id";
         return knex //(_users)
             .raw(query)
             // .select(_users + '.*', _camps_members + '.status AS member_status'/*,'tickets.ticket_id'*/)

--- a/models/camp.js
+++ b/models/camp.js
@@ -34,7 +34,7 @@ var Camp = bookshelf.Model.extend({
 
         // let _camps_members = constants.CAMP_MEMBERS_TABLE_NAME;
         // let _users = constants.USERS_TABLE_NAME;
-        let query = "SELECT users.*,camp_members.status AS member_status,SUM(IF(tickets.ticket_id>0,1,0)) AS ticket_count,SUM(tickets.inside_event) AS inside_event FROM users INNER JOIN camp_members on users.user_id=camp_members.user_id left join tickets on tickets.holder_id=users.user_id and tickets.event_id='MIDBURN2018' where camp_members.camp_id=" + this.attributes.id + " group by users.user_id";
+        let query = "SELECT users.*,camp_members.status AS member_status,SUM(IF(tickets.ticket_id>0,1,0)) AS ticket_count,SUM(tickets.inside_event) AS inside_event, camp_members.addinfo_json AS camps_members_addinfo_json FROM users INNER JOIN camp_members on users.user_id=camp_members.user_id left join tickets on tickets.holder_id=users.user_id and tickets.event_id='MIDBURN2017' where camp_members.camp_id=" + this.attributes.id + " group by users.user_id";
         return knex //(_users)
             .raw(query)
             // .select(_users + '.*', _camps_members + '.status AS member_status'/*,'tickets.ticket_id'*/)

--- a/models/constants.js
+++ b/models/constants.js
@@ -126,7 +126,7 @@ module.exports = {
     // -- system constant --
     // note: Future release will change the event_id
     // TODO We should not use this constant. We need to implement a mechanism that will allow the user to change the current event from the UI, therefore we can't rely on constant!
-    CURRENT_EVENT_ID: 'MIDBURN2018',
+    CURRENT_EVENT_ID: 'MIDBURN2017',
     events,
 
     // -- table names --

--- a/models/user.js
+++ b/models/user.js
@@ -140,7 +140,7 @@ var User = bookshelf.Model.extend({
         };
         if (prototype !== 'all') _where['__prototype'] = prototype;
         knex(_camps)
-            .select(_camps + '.*', _camps_members + '.status AS member_status', 'users_groups.entrance_quota')
+            .select(_camps + '.*', _camps_members + '.status AS member_status',_camps_members + '.addinfo_json AS camps_members_addinfo_json','users_groups.entrance_quota')
             .innerJoin(_camps_members, _camps + '.id', _camps_members + '.camp_id')
             .innerJoin('users_groups', _camps + '.id', 'users_groups.group_id')
             .where(_where)

--- a/public/scripts/controllers/camp_edit.js
+++ b/public/scripts/controllers/camp_edit.js
@@ -11,16 +11,28 @@ var angular_getMembers = function ($http, $scope, camp_id) {
             var approved_members = [];
             var total_camp_tickets = 0;
             var total_in_event = 0;
+            var preSaleTicketsCount=0;
             for (var i in members) {
-                if (['approved', 'pending', 'pending_mgr', 'approved_mgr', 'rejected'].indexOf(members[i].member_status) > -1) {
-                    _members.push(members[i]);
+                var newMember=members[i]
+                //check if the user has a pre_sale ticket 
+                //if so the set the checkbox to true 
+                if(members[i].pre_sale_ticket){
+                    newMember.pre_sale_ticket_approved=members[i].pre_sale_ticket;
+                    preSaleTicketsCount++;
                 }
-                if (['approved', 'approved_mgr'].indexOf(members[i].member_status) > -1) {
-                    approved_members.push(members[i]);
+                else{
+                    newMember.pre_sale_ticket_approved = false;
                 }
-                total_in_event += parseInt(members[i].inside_event);
-                total_camp_tickets += parseInt(members[i].ticket_count) || 0;
+                if (['approved', 'pending', 'pending_mgr', 'approved_mgr', 'rejected'].indexOf(newMember.member_status) > -1) {
+                    _members.push(newMember);
+                }
+                if (['approved', 'approved_mgr'].indexOf(newMember.member_status) > -1) {
+                    approved_members.push(newMember);
+                }
+                total_in_event += parseInt(newMember.inside_event);
+                total_camp_tickets += parseInt(newMember.ticket_count) || 0;
             }
+            $scope.preSaleTicketsCount = preSaleTicketsCount;
             $scope.members = _members;
             $scope.approved_members = approved_members;
             $scope.all_approved_members = approved_members.length;
@@ -46,7 +58,8 @@ var angular_updateUser = function ($http, $scope, action_type, user_rec) {
             delete: 'למחוק את',
             reject: 'לדחות את',
             approve_mgr: 'להפוך למנהל את',
-            remove: 'להסיר את'
+            remove: 'להסיר את',
+            pre_sale_ticket : 'לאשר כרטיס מוקדם',
         };
         tpl = {
             alert_title: "האם את/ה בטוח?",
@@ -61,7 +74,8 @@ var angular_updateUser = function ($http, $scope, action_type, user_rec) {
             delete: 'Delete',
             reject: 'Reject',
             approve_mgr: 'Set Manager',
-            remove: 'Remove'
+            remove: 'Remove',
+            pre_sale_ticket: 'Update Pre Sale Ticket',
         };
         tpl = {
             alert_title: "Are you sure?",
@@ -87,7 +101,8 @@ var angular_updateUser = function ($http, $scope, action_type, user_rec) {
                 sweetAlert(tpl.alert_success_1, tpl.alert_success_1, "success");
                 $scope.getMembers(camp_id);
             }).catch((err) => {
-                sweetAlert("Error!", "Something went wrong, please try again later " + err, "error");
+                jsonError=err.data.data.message;
+                sweetAlert("Error!", "Something went wrong, please try again later \n" + jsonError, "error");
             })
         });
 }
@@ -149,14 +164,30 @@ app.controller("campEditController", ($scope, $http, $filter) => {
             sweetAlert("Error!", "Add new member error: " + err.data.data.message, "error");
         });
     }
-    $scope.updateUser = (user_name, user_id, action_type) => {
+    $scope.updateUser = (user_name, user_id,action_type) => {
+        var camp_id = $scope.current_camp_id;
+        var user_rec = {
+            camp_id: camp_id,
+            user_name: user_name,
+            user_id: user_id,
+            addinfo_json : parsedJsonInfo,
+        }
+        angular_updateUser($http, $scope, action_type, user_rec);
+    }
+
+    //when the user wants to update a pre sale ticket
+    //this method is executed
+    $scope.updatePreSaleTicket = (user_name, user_id,action_type,pre_sale_ticket_approved) => {
         var camp_id = $scope.current_camp_id;
         var user_rec = {
             camp_id: camp_id,
             user_name: user_name,
             user_id: user_id,
         }
+   
         angular_updateUser($http, $scope, action_type, user_rec);
+        
+
     }
 });
 

--- a/public/scripts/controllers/camp_edit.js
+++ b/public/scripts/controllers/camp_edit.js
@@ -11,16 +11,28 @@ var angular_getMembers = function ($http, $scope, camp_id) {
             var approved_members = [];
             var total_camp_tickets = 0;
             var total_in_event = 0;
+            var preSaleCounter=0;
             for (var i in members) {
-                if (['approved', 'pending', 'pending_mgr', 'approved_mgr', 'rejected'].indexOf(members[i].member_status) > -1) {
-                    _members.push(members[i]);
+                var newMember=members[i]
+                if(members[i].pre_sale_ticket){
+                    newMember.pre_sale_ticket_approved=members[i].pre_sale_ticket;
+                    if(newMember.pre_sale_ticket_approved == true){
+                        preSaleCounter++;
+                    }
                 }
-                if (['approved', 'approved_mgr'].indexOf(members[i].member_status) > -1) {
-                    approved_members.push(members[i]);
+                else{
+                    newMember.pre_sale_ticket_approved = false;
                 }
-                total_in_event += parseInt(members[i].inside_event);
-                total_camp_tickets += parseInt(members[i].ticket_count) || 0;
+                if (['approved', 'pending', 'pending_mgr', 'approved_mgr', 'rejected'].indexOf(newMember.member_status) > -1) {
+                    _members.push(newMember);
+                }
+                if (['approved', 'approved_mgr'].indexOf(newMember.member_status) > -1) {
+                    approved_members.push(newMember);
+                }
+                total_in_event += parseInt(newMember.inside_event);
+                total_camp_tickets += parseInt(newMember.ticket_count) || 0;
             }
+            $scope.preSaleCounter = preSaleCounter;
             $scope.members = _members;
             $scope.approved_members = approved_members;
             $scope.all_approved_members = approved_members.length;
@@ -46,7 +58,8 @@ var angular_updateUser = function ($http, $scope, action_type, user_rec) {
             delete: 'למחוק את',
             reject: 'לדחות את',
             approve_mgr: 'להפוך למנהל את',
-            remove: 'להסיר את'
+            remove: 'להסיר את',
+            pre_sale_ticket : 'לאשר כרטיס מוקדם ל',
         };
         tpl = {
             alert_title: "האם את/ה בטוח?",
@@ -61,7 +74,8 @@ var angular_updateUser = function ($http, $scope, action_type, user_rec) {
             delete: 'Delete',
             reject: 'Reject',
             approve_mgr: 'Set Manager',
-            remove: 'Remove'
+            remove: 'Remove',
+            pre_sale_ticket: 'Update Pre Sale Ticket',
         };
         tpl = {
             alert_title: "Are you sure?",
@@ -149,14 +163,37 @@ app.controller("campEditController", ($scope, $http, $filter) => {
             sweetAlert("Error!", "Add new member error: " + err.data.data.message, "error");
         });
     }
-    $scope.updateUser = (user_name, user_id, action_type) => {
+    $scope.updateUser = (user_name, user_id,action_type) => {
+        var camp_id = $scope.current_camp_id;
+        var user_rec = {
+            camp_id: camp_id,
+            user_name: user_name,
+            user_id: user_id,
+            addinfo_json : parsedJsonInfo,
+        }
+        angular_updateUser($http, $scope, action_type, user_rec);
+    }
+    $scope.updatePreSaleTicket = (user_name, user_id,action_type,pre_sale_ticket_approved) => {
         var camp_id = $scope.current_camp_id;
         var user_rec = {
             camp_id: camp_id,
             user_name: user_name,
             user_id: user_id,
         }
-        angular_updateUser($http, $scope, action_type, user_rec);
+        if(document.getElementById('pre_sale_ticket_quota').value <= $scope.preSaleCounter && pre_sale_ticket_approved == false)
+        {
+            var lang = $scope.lang;
+            if(lang == "en"){
+                sweetAlert("Pre sale ticket quota exceeded");
+            }
+            else{
+                sweetAlert("עברת את מכסת הכרטיסים המותרת");
+            }
+        } else{
+            angular_updateUser($http, $scope, action_type, user_rec);
+        }
+        
+
     }
 });
 

--- a/routes/api_camps_routes.js
+++ b/routes/api_camps_routes.js
@@ -197,7 +197,7 @@ var __camps_update_status = (camp_id, user_id, action, camp_mgr, res) => {
                             }
                         }
 
-                        //if we are going to set a oresale ticket to true, e eed to check if the quota is ok
+                        //if we are going to set a pre sale ticket to true, we need to check if the quota is ok
                         if(jsonInfo.pre_sale_ticket == "true"){
                             //first count how many pre sale tickets are assinged to the camp members
                             var preSaleTicketsCount=0;
@@ -210,7 +210,7 @@ var __camps_update_status = (camp_id, user_id, action, camp_mgr, res) => {
                                 }    
                             }
 
-                            //if the pre sale ticket count equa or higher than the qouta
+                            //if the pre sale ticket count equal or higher than the quota
                             //reject the reuest 
                             if(preSaleTicketsCount >= camp.attributes.pre_sale_tickets_quota)
                             {

--- a/routes/api_camps_routes.js
+++ b/routes/api_camps_routes.js
@@ -51,6 +51,7 @@ var __camps_update_status = (camp_id, user_id, action, camp_mgr, res) => {
             var user = camp.isUserInCamp(user_id, true);
             var camp_manager = camp.isCampManager(camp.attributes.main_contact);
             // camp manager commands
+            var addinfo_jason;
             if (action === 'approve_new_mgr' && (camp_mgr_id === camp.attributes.main_contact || isAdmin)) {
                 new_status = 'approved';
                 if (!user) {
@@ -76,6 +77,8 @@ var __camps_update_status = (camp_id, user_id, action, camp_mgr, res) => {
                     new_status = 'rejected';
                 } else if (user && action === "revive") {
                     new_status = 'pending';
+                } else if (user && action === "pre_sale_ticket"){
+                    addinfo_jason_subAction ="pre_sale_ticket";
                 } else if (action === "request_mgr") {
                     if (group_options.auto_approve_new_members) {
                         new_status = 'approved';
@@ -122,7 +125,130 @@ var __camps_update_status = (camp_id, user_id, action, camp_mgr, res) => {
                     }
                 }
             }
-            if (new_status) {
+
+            var _after_update = () => {
+                var data = {
+                    camp_id: camp.attributes.id,
+                    user_id: user_id,
+                };
+                console.log(action + " from camp " + data.camp_id + " of user " + data.user_id + " / status: " + data.status);
+                if (group_options.send_mail && mail_delivery.template !== '') {
+                    if (user) {
+                        let email = mail_delivery.to_mail !== '' ? mail_delivery.to_mail : user.email;
+                        //emailDeliver(email, mail_delivery.subject, mail_delivery.template, { user: user, camp: camp.toJSON(), camp_manager: camp_manager }); // notify the user
+                    } else {
+                        User.forge({ user_id: user_id }).fetch().then((user) => {
+                            let email = mail_delivery.to_mail !== '' ? mail_delivery.to_mail : user.attributes.email;
+                           // emailDeliver(email, mail_delivery.subject, mail_delivery.template, { user: user.toJSON(), camp: camp.toJSON(), camp_manager: camp_manager }); // notify the user
+                        });
+                    }
+                }
+                var res_data = { data: { member: data } };
+                if (action === 'approve_new_mgr') {
+                    res_data.data.message = 'camp created';
+                    res_data.data.camp_id = camp_id;
+                }
+                res.status(200).json(res_data);
+
+            }
+
+            //check if the request is to update the addinfo_json column 
+            if(addinfo_jason_subAction){
+                var userData = {
+                    camp_id: camp.attributes.id,
+                    user_id: user_id,
+   
+                };
+                
+                /*
+                here we pass the query info from the SQL 
+                and check the json inof
+                */
+                function _get_json_data (resp,addinfo_jason_subAction){
+                    var userData = {
+                        camp_id: camp.attributes.id,
+                        user_id: user_id,
+                        addinfo_json : resp[0].addinfo_json,
+                    };
+                    var jsonInfo;
+                    //first check if its null
+                    //if so then set it the value
+                    if(addinfo_jason_subAction == "pre_sale_ticket"){
+
+                        //if the user is not approved yet in the camp
+                        //reject the reuest 
+                        if(user.member_status === 'pending')
+                        {
+                            res.status(500);
+                            throw new Error(res.json({ error: true, data: {message: "Cannot assign Pre-sale ticket to pending user" }}));   
+                        }
+
+                        if(userData.addinfo_json == null){
+                            jsonInfo = {"pre_sale_ticket": "true"};
+                        }
+                        else{
+                            //if the object is not null then parse it and toggle the current value 
+                            jsonInfo=JSON.parse(userData.addinfo_json);
+                            if(jsonInfo.pre_sale_ticket == "true"){
+                                jsonInfo.pre_sale_ticket = "false";
+                            } 
+                            else {
+                                jsonInfo.pre_sale_ticket ="true";
+                            }
+                        }
+
+                        //if we are going to set a oresale ticket to true, e eed to check if the quota is ok
+                        if(jsonInfo.pre_sale_ticket == "true"){
+                            //first count how many pre sale tickets are assinged to the camp members
+                            var preSaleTicketsCount=0;
+                            for (var i in users) {
+                                if(users[i].camps_members_addinfo_json){
+                                    var addinfo_json = JSON.parse(users[i].camps_members_addinfo_json);
+                                    if(addinfo_json.pre_sale_ticket == "true"){
+                                        preSaleTicketsCount++
+                                    }
+                                }    
+                            }
+
+                            //if the pre sale ticket count equa or higher than the qouta
+                            //reject the reuest 
+                            if(preSaleTicketsCount >= camp.attributes.pre_sale_tickets_quota)
+                            {
+                                res.status(500);
+                                throw new Error(res.json({ error: true, data: {message: "exceed pre sale tickets quota" }}));   
+                            }
+                        }
+                    }
+                    
+                    //update the table with the new value of the json info
+                    //on success go to _after_update callback
+                    jsonInfo = JSON.stringify(jsonInfo) 
+                    knex(constants.CAMP_MEMBERS_TABLE_NAME).update({addinfo_json : jsonInfo})
+                        .where({
+                            camp_id : userData.camp_id, 
+                            user_id : userData.user_id
+                        })
+                        .then(_after_update).catch((e)=>{
+                        console.log(e);
+                    })
+                }
+
+                
+                //select the addinfo_json column from the camp member table
+                knex(constants.CAMP_MEMBERS_TABLE_NAME).select('addinfo_json')
+                .where({
+                    camp_id : userData.camp_id, 
+                    user_id : userData.user_id
+                })
+                .then( resp =>{
+                    //pass the response to the process method
+                    _get_json_data(resp,addinfo_jason_subAction)
+                })
+                .catch((e)=>{
+                    console.log(e);
+                })
+            }
+            else if (new_status) {
                 var data = {
                     camp_id: camp.attributes.id,
                     user_id: user_id,
@@ -134,27 +260,7 @@ var __camps_update_status = (camp_id, user_id, action, camp_mgr, res) => {
                 } else {
                     query = 'UPDATE ' + constants.CAMP_MEMBERS_TABLE_NAME + ' SET status="' + data.status + '" WHERE camp_id=' + data.camp_id + ' AND user_id=' + data.user_id + ';';
                 }
-                var _after_update = () => {
-                    console.log(action + " from camp " + data.camp_id + " of user " + data.user_id + " / status: " + data.status);
-                    if (group_options.send_mail && mail_delivery.template !== '') {
-                        if (user) {
-                            let email = mail_delivery.to_mail !== '' ? mail_delivery.to_mail : user.email;
-                            emailDeliver(email, mail_delivery.subject, mail_delivery.template, { user: user, camp: camp.toJSON(), camp_manager: camp_manager }); // notify the user
-                        } else {
-                            User.forge({ user_id: user_id }).fetch().then((user) => {
-                                let email = mail_delivery.to_mail !== '' ? mail_delivery.to_mail : user.attributes.email;
-                                emailDeliver(email, mail_delivery.subject, mail_delivery.template, { user: user.toJSON(), camp: camp.toJSON(), camp_manager: camp_manager }); // notify the user
-                            });
-                        }
-                    }
-                    var res_data = { data: { member: data } };
-                    if (action === 'approve_new_mgr') {
-                        res_data.data.message = 'camp created';
-                        res_data.data.camp_id = camp_id;
-                    }
-                    res.status(200).json(res_data);
-
-                }
+                
                 knex.raw(query).then(_after_update);
             } else {
                 res.status(404).json({ error: true, data: { message: "Cannot execute this command." } });
@@ -507,7 +613,7 @@ module.exports = (app, passport) => {
         var user_id = req.params.user_id;
         var camp_id = req.params.camp_id;
         var action = req.params.action;
-        var actions = ['approve', 'remove', 'revive', 'reject', 'approve_mgr', 'remove_mgr'];
+        var actions = ['approve', 'remove', 'revive', 'reject', 'approve_mgr', 'remove_mgr', 'pre_sale_ticket'];
         if (actions.indexOf(action) > -1) {
             __camps_update_status(camp_id, user_id, action, req.user, res);
         } else {
@@ -852,6 +958,7 @@ module.exports = (app, passport) => {
                             member.cell_phone = '';
                             member.name = '';
                         }
+                        
                         delete member.email;
                         delete member.first_name;
                         delete member.last_name;
@@ -866,6 +973,18 @@ module.exports = (app, passport) => {
                         return member;
                     });
                 }
+                
+                for (var i in members) {
+                    if(members[i].camps_members_addinfo_json){
+                        var addinfo_json = JSON.parse(members[i].camps_members_addinfo_json);
+                        if(addinfo_json.pre_sale_ticket == "true"){
+                            members[i].pre_sale_ticket = true;
+                        }
+                    } else{
+                        members[i].pre_sale_ticket = false;
+                    }    
+                }
+
                 result = camp.parsePrototype(req.user);
 
                 if (isCampManager || (result && result.isAdmin)) {

--- a/routes/api_camps_routes.js
+++ b/routes/api_camps_routes.js
@@ -135,11 +135,11 @@ var __camps_update_status = (camp_id, user_id, action, camp_mgr, res) => {
                 if (group_options.send_mail && mail_delivery.template !== '') {
                     if (user) {
                         let email = mail_delivery.to_mail !== '' ? mail_delivery.to_mail : user.email;
-                        //emailDeliver(email, mail_delivery.subject, mail_delivery.template, { user: user, camp: camp.toJSON(), camp_manager: camp_manager }); // notify the user
+                        emailDeliver(email, mail_delivery.subject, mail_delivery.template, { user: user, camp: camp.toJSON(), camp_manager: camp_manager }); // notify the user
                     } else {
                         User.forge({ user_id: user_id }).fetch().then((user) => {
                             let email = mail_delivery.to_mail !== '' ? mail_delivery.to_mail : user.attributes.email;
-                           // emailDeliver(email, mail_delivery.subject, mail_delivery.template, { user: user.toJSON(), camp: camp.toJSON(), camp_manager: camp_manager }); // notify the user
+                            emailDeliver(email, mail_delivery.subject, mail_delivery.template, { user: user.toJSON(), camp: camp.toJSON(), camp_manager: camp_manager }); // notify the user
                         });
                     }
                 }
@@ -174,6 +174,15 @@ var __camps_update_status = (camp_id, user_id, action, camp_mgr, res) => {
                     //first check if its null
                     //if so then set it the value
                     if(addinfo_jason_subAction == "pre_sale_ticket"){
+
+                        //if the user is not approved yet in the
+                        //reject the reuest 
+                        if(user.member_status === 'pending')
+                        {
+                            res.status(500);
+                            throw new Error(res.json({ error: true, data: {message: "Cannot assign Pre-sale ticket to pending user" }}));   
+                        }
+
                         if(userData.addinfo_json == null){
                             jsonInfo = {"pre_sale_ticket": "true"};
                         }
@@ -187,7 +196,30 @@ var __camps_update_status = (camp_id, user_id, action, camp_mgr, res) => {
                                 jsonInfo.pre_sale_ticket ="true";
                             }
                         }
+
+                        //if we are going to set a oresale ticket to true, e eed to check if the quota is ok
+                        if(jsonInfo.pre_sale_ticket == "true"){
+                            //first count how many pre sale tickets are assinged to the camp members
+                            var preSaleTicketsCount=0;
+                            for (var i in users) {
+                                if(users[i].camps_members_addinfo_json){
+                                    var addinfo_json = JSON.parse(users[i].camps_members_addinfo_json);
+                                    if(addinfo_json.pre_sale_ticket == "true"){
+                                        preSaleTicketsCount++
+                                    }
+                                }    
+                            }
+
+                            //if the pre sale ticket count equa or higher than the qouta
+                            //reject the reuest 
+                            if(preSaleTicketsCount >= camp.attributes.pre_sale_tickets_quota)
+                            {
+                                res.status(500);
+                                throw new Error(res.json({ error: true, data: {message: "exceed pre sale tickets quota" }}));   
+                            }
+                        }
                     }
+                    
                     //update the table with the new value of the json info
                     //on success go to _after_update callback
                     jsonInfo = JSON.stringify(jsonInfo) 
@@ -201,6 +233,7 @@ var __camps_update_status = (camp_id, user_id, action, camp_mgr, res) => {
                     })
                 }
 
+                
                 //select the addinfo_json column from the camp member table
                 knex(constants.CAMP_MEMBERS_TABLE_NAME).select('addinfo_json')
                 .where({

--- a/routes/api_camps_routes.js
+++ b/routes/api_camps_routes.js
@@ -171,8 +171,8 @@ var __camps_update_status = (camp_id, user_id, action, camp_mgr, res) => {
                         addinfo_json : resp[0].addinfo_json,
                     };
                     var jsonInfo;
-                    //first check if its null
-                    //if so then set it the value
+                    
+                    //check for the sub action in the json info
                     if(addinfo_jason_subAction == "pre_sale_ticket"){
 
                         //if the user is not approved yet in the
@@ -183,6 +183,8 @@ var __camps_update_status = (camp_id, user_id, action, camp_mgr, res) => {
                             throw new Error(res.json({ error: true, data: {message: "Cannot assign Pre-sale ticket to pending user" }}));   
                         }
 
+                        //check if the json info is null
+                         //if so then set it the value as this is the first init of the data
                         if(userData.addinfo_json == null){
                             jsonInfo = {"pre_sale_ticket": "true"};
                         }
@@ -974,9 +976,11 @@ module.exports = (app, passport) => {
                     });
                 }
                 
+                //check eahc memebr and send to the client the jason info
                 for (var i in members) {
                     if(members[i].camps_members_addinfo_json){
                         var addinfo_json = JSON.parse(members[i].camps_members_addinfo_json);
+                        //check for pre sale ticket info and update the memebr
                         if(addinfo_json.pre_sale_ticket == "true"){
                             members[i].pre_sale_ticket = true;
                         }

--- a/views/pages/camps/edit.jade
+++ b/views/pages/camps/edit.jade
@@ -156,6 +156,10 @@ block content
                                     .col-xs-12
                                         label(for='entrance_quota')=t('camps:edit.early_arrival_quota')
                                         input.form-control(id='entrance_quota', name='entrance_quota', value=(isNew ? 0 : (camp.entrance_quota === null ? '' : '#{camp.entrance_quota}')),readonly=(!isAdmin ? 'true' : undefined))
+                                .col-md-4
+                                    .col-xs-12
+                                        label(for='pre_sale_ticket_quota')=t('camps:edit.pre_sale_ticket_quota')
+                                        input.form-control(id='pre_sale_ticket_quota', name='pre_sale_ticket_quota', value=(isNew ? 0 : (camp.pre_sale_tickets_quota === null ? 0 : '#{camp.pre_sale_tickets_quota}')),readonly='true')
 
             //- Card 2
             .card.card-second.card-hide

--- a/views/pages/camps/index_admin.jade
+++ b/views/pages/camps/index_admin.jade
@@ -37,6 +37,7 @@ block content
                             //- th.hidden-xs(ng-click='changeOrderBy("created_at")')=t(t_prefix+'stats.created_at')
                             th.published(ng-click='changeOrderBy("published")')=t(t_prefix+'stats.published')
                             th.entrance_quota(ng-click='changeOrderBy("entrance_quota")')=t('camps:stats.entrance_quota')
+                            th.pre_sale_ticket_quota(ng-click='changeOrderBy("pre_sale_ticket_quota")')=t('camps:stats.pre_sale_ticket_quota')
                             //- th.facebook_page_url=t(t_prefix+'stats.facebook_page_url')
                             th()=t(t_prefix+'members.actions')
                             //- th.admin-edit=t(t_prefix+'stats.edit')
@@ -57,6 +58,7 @@ block content
                             td {{ camp.web_published }}
                             //- td
                             td {{ camp.entrance_quota }}
+                            td {{ camp.pre_sale_ticket_quota }}
                             td
                                 //- a.Btn(ng-href=`/${language}/camps/{{camp.id}}` + '/edit')
                                     span(class='glyphicon glyphicon-pencil')

--- a/views/pages/camps/partials/members_table.jade
+++ b/views/pages/camps/partials/members_table.jade
@@ -8,6 +8,7 @@ table.table.table-striped.table-hover
         th(ng-click='changeOrderBy("member_status_i18n")')=t('camps:members.status')
         th(ng-click='changeOrderBy("ticket_count")')=t('camps:members.ticket_count')
         th(ng-click='changeOrderBy("inside_event")')=t('camps:members.inside_event')
+        th(ng-click='changeOrderBy("pre_sale_ticket_approved")')=t('camps:members.pre_sale_ticket_approved')
         //- th(ng-click='changeOrderBy("earlyArrival")')=t('camps:members.early_arrival')
         th()=t('camps:members.actions')
     tbody
@@ -19,6 +20,8 @@ table.table.table-striped.table-hover
             td {{member.member_status_i18n}}
             td {{member.ticket_count}}
             td {{member.inside_event}}
+            td 
+                input(id='pre_sale_ticket_approved' type="checkbox" name="ticket_approved" ng-checked="{{member.pre_sale_ticket_approved}}" ng-model="member.pre_sale_ticket_approved" disabled)
             //- td {{member.earlyArrival ? 'yes':'no'}}
             td
                 a.cursor-p(ng-click='updateUser(member.name, member.user_id, "reject")', ng-if="member.can_reject") &nbsp;
@@ -41,9 +44,25 @@ table.table.table-striped.table-hover
                     button.btn.btn-xs 
                         span(class='glyphicon glyphicon-remove')
                         =t('camps:members.remove')
+                a.cursor-p(ng-click='updatePreSaleTicket(member.name, member.user_id ,"pre_sale_ticket",member.pre_sale_ticket_approved)', ng-if="member.pre_sale_ticket_approved === false") &nbsp;
+                    button.btn.btn-xs
+                        span(class='glyphicon glyphicon-ok' )
+                        =t('camps:members.pre_sale_ticket_approved')
+                a.cursor-p(ng-click='updatePreSaleTicket(member.name, member.user_id ,"pre_sale_ticket",member.pre_sale_ticket_approved)' ng-if="member.pre_sale_ticket_approved === true") &nbsp;
+                    button.btn.btn-xs
+                        span(class='glyphicon glyphicon-remove' )
+                        =t('camps:members.pre_sale_ticket_remove')
+                        
+
+                       
+
+                       
 .col-xs-6
     h4=t('camps:admin_index.total_approved_members')
         span.badge {{all_approved_members}}
 .col-xs-6
     h4=t('camps:admin_index.total_camp_tickets')
         span.badge {{total_camp_tickets}}
+.col-xs-6
+    h4=t(t('camps:edit.pre_sale_ticket_count'))
+        span.badge {{preSaleTicketsCount}}

--- a/views/pages/camps/partials/members_table.jade
+++ b/views/pages/camps/partials/members_table.jade
@@ -8,6 +8,7 @@ table.table.table-striped.table-hover
         th(ng-click='changeOrderBy("member_status_i18n")')=t('camps:members.status')
         th(ng-click='changeOrderBy("ticket_count")')=t('camps:members.ticket_count')
         th(ng-click='changeOrderBy("inside_event")')=t('camps:members.inside_event')
+        th(ng-click='changeOrderBy("pre_sale_ticket_approved")')=t('camps:members.pre_sale_ticket_approved')
         //- th(ng-click='changeOrderBy("earlyArrival")')=t('camps:members.early_arrival')
         th()=t('camps:members.actions')
     tbody
@@ -19,6 +20,8 @@ table.table.table-striped.table-hover
             td {{member.member_status_i18n}}
             td {{member.ticket_count}}
             td {{member.inside_event}}
+            td 
+                input(id='pre_sale_ticket_approved' type="checkbox" name="ticket_approved" ng-checked="{{member.pre_sale_ticket_approved}}" ng-model="member.pre_sale_ticket_approved" disabled)
             //- td {{member.earlyArrival ? 'yes':'no'}}
             td
                 a.cursor-p(ng-click='updateUser(member.name, member.user_id, "reject")', ng-if="member.can_reject") &nbsp;
@@ -41,6 +44,10 @@ table.table.table-striped.table-hover
                     button.btn.btn-xs 
                         span(class='glyphicon glyphicon-remove')
                         =t('camps:members.remove')
+                a.cursor-p(ng-click='updatePreSaleTicket(member.name, member.user_id ,"pre_sale_ticket",member.pre_sale_ticket_approved)') &nbsp;
+                    button.btn.btn-xs 
+                        span(class='glyphicon glyphicon-remove')
+                        =t('camps:members.pre_sale_ticket_approved')
 .col-xs-6
     h4=t('camps:admin_index.total_approved_members')
         span.badge {{all_approved_members}}


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->

### Proposed solution
New pre sale tickets option, new button is given to add/remove pre sale ticket for each user
and saved in the DB in addinfo_json column in camp_members table
on server side, validation check is done for:
    1. user is approved in the camp
    2. pre sale quota doesn't exceed 

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->


### Testing Done
looks ok for basic validation
currently there is no check if the manager can approve, need to understand which users in the camp can add/remove tickets


<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Spark dependencies -->
<!-- 3. Make sure your code is compliant with the [Spark styleguide](CONTRIBUTING.md) -->
<!-- 4. If your PR fixes an issue, reference that issue -->
<!-- 5. If your PR has lots of commits, **rebase** first -->
<!-- 6. Run `npm test` before submitting your PR -->
