### PR TITLE
presale input control date

### DIFF
--- a/public/scripts/controllers/camp_manage.js
+++ b/public/scripts/controllers/camp_manage.js
@@ -35,6 +35,8 @@ app.controller("manageCampsController", function ($scope, $http, $filter) {
     //     }, 500)
     // });
 
+    $scope.hasPresaleStarted = presaleTickestStartTime < new Date();
+
     $scope.removeCamp = (camp_id) => {
         var agree_remove = confirm('Remove camp\n\n\nThis action will remove camp #' + camp_id + '.\n\n\n---\n Are you sure?');
         if (agree_remove) {

--- a/routes/api_camps_routes.js
+++ b/routes/api_camps_routes.js
@@ -165,18 +165,27 @@ var __camps_update_status = (camp_id, user_id, action, camp_mgr, res) => {
    
                 };
 
-                //select the addinfo_json column from the camp member table
-                knex(constants.CAMP_MEMBERS_TABLE_NAME).select('user_id','addinfo_json')
+                //select the addinfo_json column from the camp member table, and events addinfo_json
+                let campsMembersTable = constants.CAMP_MEMBERS_TABLE_NAME;
+                let eventsTable = constants.EVENTS_TABLE_NAME;
+                knex(campsMembersTable)
+                    .rightOuterJoin(eventsTable, `event_id`, constants.CURRENT_EVENT_ID ) //TODO use current event id from session
+                    .select(`${campsMembersTable}.user_id`, `${campsMembersTable}.addinfo_json`, `${eventsTable}.addinfo_json`)
                 .where({
                     camp_id : userData.camp_id, 
                     user_id : userData.user_id
                 })
                 .then(resp => {
 
+                    let userAddInfo = resp[0].camp_members.addinfo_json;
+                    let eventAddInfo = {
+                        presaleStart: new Date(resp[0].events.addinfo_json.start_presale_tickets),
+                        presaleEnd: new Date(resp[0].events.addinfo_json.end_presale_tickets)
+                        }
                     let jsonInfo;
                     try {
                         //pass the response to the process method
-                        jsonInfo = Modify_User_AddInfo(resp[0].addinfo_json,addinfo_jason_subAction,camp,users,user,isAdmin);
+                        jsonInfo = Modify_User_AddInfo(userAddInfo,eventAddInfo,addinfo_jason_subAction,camp,users,user,isAdmin);
                     } catch (err) {
                         res.status(500);
                         throw new Error(res.json({error: true, data: { message: err.message }}));
@@ -229,7 +238,7 @@ var __camps_update_status = (camp_id, user_id, action, camp_mgr, res) => {
 here we pass the query info from the SQL 
 and check the json info, the method will throw and error if failed
 */
-function Modify_User_AddInfo (info, addinfo_jason_subAction,camp, users, user, isAdmin) {
+function Modify_User_AddInfo (info,eventInfo, addinfo_jason_subAction,camp, users, user, isAdmin) {
     
     var userData = info;
 
@@ -244,8 +253,8 @@ function Modify_User_AddInfo (info, addinfo_jason_subAction,camp, users, user, i
         //TODO once the event table will be updated with presale ticket time, this needs to be replace
         if (isAdmin === false) {
             var currentTime = new Date();
-            var start=new Date(constants.PRESALE_TICKETS_START_DATE);
-            var end=new Date(constants.PRESALE_TICKETS_END_DATE);
+            var start = eventInfo.presaleStart;
+            var end = eventInfo.presaleEnd;
             if (currentTime.getTime() < start.getTime() || currentTime.getTime() > end.getTime()) {
                 throw new Error("PreSale Tickes selection is currently closed");
             }

--- a/routes/camps_routes.js
+++ b/routes/camps_routes.js
@@ -263,6 +263,7 @@ module.exports = function (app, passport) {
                 breadcrumbs: req.breadcrumbs(),
                 __groups_prototype: 'theme_camps',
                 t_prefix: 'camps:',
+                presaleTicketsStartDate: constants.PRESALE_TICKETS_START_DATE,
                 isCamp: true,
             });
         } else {

--- a/views/pages/camps/index_admin.jade
+++ b/views/pages/camps/index_admin.jade
@@ -3,6 +3,7 @@ block content
     .camps.camp_admin_index(ng-app="ngCamps")
         script.
             var groups_prototype="#{__groups_prototype}";
+            var presaleTickestStartTime = new Date("#{presaleTicketsStartDate}");
         .container.col-md-12
             h1=t(t_prefix+'dash.title')
             p.lead.text-muted=t(t_prefix+'dash.desc')
@@ -59,8 +60,8 @@ block content
                             //- td
                             td {{ camp.entrance_quota }}
                             td 
-                                input( type="number" name="pre_sale_tickets_quota" ondblclick="this.readOnly=''" readonly="true" ng-value="camp.pre_sale_tickets_quota !== null ? camp.pre_sale_tickets_quota : 0" ng-model="camp.pre_sale_tickets_quota_input" ng-model-options="{updateOn : 'change'}"  ng-change='updatePreSaleQuota(camp.id,camp.pre_sale_tickets_quota_input)')
-                            td
+                                input( type="number" name="pre_sale_tickets_quota" ondblclick="this.readOnly=''" readonly="true" ng-value="camp.pre_sale_tickets_quota !== null ? camp.pre_sale_tickets_quota : 0" ng-model="camp.pre_sale_tickets_quota_input" ng-model-options="{updateOn : 'change'}"  ng-change='updatePreSaleQuota(camp.id,camp.pre_sale_tickets_quota_input)' ng-click="hasPresaleStarted")
+                            td                                
                                 //- a.Btn(ng-href=`/${language}/camps/{{camp.id}}` + '/edit')
                                     span(class='glyphicon glyphicon-pencil')
                                     span(class='sr-only' aria-hidden='true') Edit Camp

--- a/views/pages/camps/index_admin.jade
+++ b/views/pages/camps/index_admin.jade
@@ -60,7 +60,7 @@ block content
                             //- td
                             td {{ camp.entrance_quota }}
                             td 
-                                input( type="number" name="pre_sale_tickets_quota" ondblclick="this.readOnly=''" readonly="true" ng-value="camp.pre_sale_tickets_quota !== null ? camp.pre_sale_tickets_quota : 0" ng-model="camp.pre_sale_tickets_quota_input" ng-model-options="{updateOn : 'change'}"  ng-change='updatePreSaleQuota(camp.id,camp.pre_sale_tickets_quota_input)' ng-click="hasPresaleStarted")
+                                input( type="number" name="pre_sale_tickets_quota" ondblclick="this.readOnly=''" readonly="true" ng-value="camp.pre_sale_tickets_quota !== null ? camp.pre_sale_tickets_quota : 0" ng-model="camp.pre_sale_tickets_quota_input" ng-model-options="{updateOn : 'change'}"  ng-change='updatePreSaleQuota(camp.id,camp.pre_sale_tickets_quota_input)' ng-disabled="hasPresaleStarted")
                             td                                
                                 //- a.Btn(ng-href=`/${language}/camps/{{camp.id}}` + '/edit')
                                     span(class='glyphicon glyphicon-pencil')


### PR DESCRIPTION
### on the http://localhost:3000/he/camps-admin page 
presale input column would be enabled as long as current date is still before event presale tickets start date

--------------
note: constants.PRESALE_TICKETS_START_DATE should come form the actual event (not hard coded)
#### please note to merge and squash together!
closes #476 