### PR TITLE
Event communities copy

### DIFF
--- a/public/scripts/controllers/events.js
+++ b/public/scripts/controllers/events.js
@@ -28,7 +28,7 @@ events_app.controller("eventsFormController", ($scope, $http, $filter) => {
     //initiate a new event, or fetch evet details for edit.
     $scope.event = newEvent ? { addinfo_json: { created_at: new Date() } } : editEvent;
     $scope.eventStarted = $scope.event.addinfo_json.start_date < new Date();
-    $scope.isCommunityCampsCopied = $scope.event.addinfo_json.community_camps ? true : false;
+    $scope.isCommunityCampsCopied = $scope.event.addinfo_json.community_camps;
 
     $scope.createEvent = () => {
         var _url = '/events/new';

--- a/public/scripts/controllers/events.js
+++ b/public/scripts/controllers/events.js
@@ -28,6 +28,7 @@ events_app.controller("eventsFormController", ($scope, $http, $filter) => {
     //initiate a new event, or fetch evet details for edit.
     $scope.event = newEvent ? { addinfo_json: { created_at: new Date() } } : editEvent;
     $scope.eventStarted = $scope.event.addinfo_json.start_date < new Date();
+    $scope.isCommunityCampsCopied = $scope.event.addinfo_json.community_camps ? true : false;
 
     $scope.createEvent = () => {
         var _url = '/events/new';
@@ -35,7 +36,7 @@ events_app.controller("eventsFormController", ($scope, $http, $filter) => {
             .success((response) => {
                 var withCamps = "";
                 if ($scope.event.addinfo_json.community_camps) {
-                    await $scope.copyCommunities();
+                    $scope.copyCommunities();
                     withCamps = "with camps"
                 }
                 alert(`new event created ${withCamps}!`);
@@ -50,7 +51,13 @@ events_app.controller("eventsFormController", ($scope, $http, $filter) => {
         var _url = '/events/update';
         $http.put(_url, $scope.event)
             .success(function (response) {
-                alert("Event updated");
+                var withCamps = "";
+                if ($scope.event.addinfo_json.community_camps) {
+                    $scope.copyCommunities();
+                    withCamps = ",and camps added"
+                    $scope.isCommunityCampsCopied = true;
+                }
+                alert(`Event updated ${withCamps}!`);
             })
             .error(() => {
                 alert("Something went wrong");
@@ -61,7 +68,7 @@ events_app.controller("eventsFormController", ($scope, $http, $filter) => {
         let fromEvent = $scope.event.ext_id_event_id;
         let toEvent = $scope.event.event_id;
         let _url = `/camps/copyCommunities/${fromEvent}/${toEvent}`;
-        $http.put(_url, $scope.event)
+        $http.post(_url, $scope.event)
             .success((response) => {
                 console.log("communities copied");
             })

--- a/public/scripts/controllers/events.js
+++ b/public/scripts/controllers/events.js
@@ -1,6 +1,6 @@
 var events_all;
 
-__get_all_events = function ($http, on_success) {
+__get_all_events = ($http, on_success) => {
     if (events_all) {
         on_success(events_all);
     } else {
@@ -26,30 +26,49 @@ events_app.controller("eventsController", ($scope, $http, $filter) => {
 
 events_app.controller("eventsFormController", ($scope, $http, $filter) => {
     //initiate a new event, or fetch evet details for edit.
-    $scope.event = newEvent ? {addinfo_json: {created_at: new Date()}} : editEvent;
+    $scope.event = newEvent ? { addinfo_json: { created_at: new Date() } } : editEvent;
     $scope.eventStarted = $scope.event.addinfo_json.start_date < new Date();
 
-    $scope.sendEvent = function () {
+    $scope.createEvent = () => {
         var _url = '/events/new';
         $http.post(_url, $scope.event)
-        .success(function(response) {
-            alert("Event added to DB");
-            document.location.href = '/he/events-admin';
-        })
-        .error(function() {
-            alert("Something went wrong");
-        });
+            .success((response) => {
+                var withCamps = "";
+                if ($scope.event.addinfo_json.community_camps) {
+                    await $scope.copyCommunities();
+                    withCamps = "with camps"
+                }
+                alert(`new event created ${withCamps}!`);
+                document.location.href = '/he/events-admin';
+
+            }).error(() => {
+                alert("Something went wrong");
+            });
     }
 
-    $scope.updateEvent = function () {
+    $scope.updateEvent = () => {
         var _url = '/events/update';
         $http.put(_url, $scope.event)
-        .success(function(response) {
-            alert("Event updated");
-        })
-        .error(function() {
-            alert("Something went wrong");
-        });
+            .success(function (response) {
+                alert("Event updated");
+            })
+            .error(() => {
+                alert("Something went wrong");
+            });
+    }
+
+    $scope.copyCommunities = () => {
+        let fromEvent = $scope.event.ext_id_event_id;
+        let toEvent = $scope.event.event_id;
+        let _url = `/camps/copyCommunities/${fromEvent}/${toEvent}`;
+        $http.put(_url, $scope.event)
+            .success((response) => {
+                console.log("communities copied");
+            })
+            .error(() => {
+                alert("Something went wrong");
+            });
+
     }
 
 })// End of Angular Controller

--- a/routes/api_camps_routes.js
+++ b/routes/api_camps_routes.js
@@ -1364,4 +1364,31 @@ module.exports = (app, passport) => {
             });
     })
 
+    /*
+    * API: duplicate all camp from previous event to a new event
+    * fromEvent: event to copy camps from
+    * toEvent: event to create the new camps into
+    * request => /camps/MIDBURN2017/MIDBURN2018
+    * note: will duplicate the camps table with new camps id
+    */
+    app.post('/camps/copyCommunities/:fromEvent/:toEvent',
+        [/*userRole.isLoggedIn(), userRole.isAdmin()*/],
+        (req, res) => {
+            console.log("############### here ############")
+            log.debug(`EventsAPI copyCommunities ${_.get(req, 'params.event')}`);
+            
+            let fromEvent = req.params.fromEvent;
+            let toEvent = req.params.toEvent;
+            console.log(`fromEvent: ${fromEvent} - toEvent: ${toEvent}`)
+            // sql query to duplicate all previous event camps into new camps with auto generated event id AND update date as current date.
+            let sql = `INSERT INTO camps
+                        SELECT created_at, CURDATE() as updated_at, 0 as id, ${toEvent} as event_id, __prototype, camp_name_he, camp_name_en, camp_desc_he, camp_desc_en, type, status, web_published, camp_activity_time, child_friendly, noise_level, public_activity_area_sqm, public_activity_area_desc, support_art, location_comments, camp_location_street, camp_location_street_time, camp_location_area, addinfo_json, main_contact, moop_contact, safety_contact, contact_person_name, contact_person_email, contact_person_phone, accept_families, facebook_page_url, contact_person_id, pre_sale_tickets_quota
+                        FROM camps 
+                        WHERE event_id='${fromEvent}'`;
+            knex.raw(sql).then(
+                res.send(200)
+            );
+
+        });
+
 }

--- a/routes/api_camps_routes.js
+++ b/routes/api_camps_routes.js
@@ -1372,21 +1372,18 @@ module.exports = (app, passport) => {
     * note: will duplicate the camps table with new camps id
     */
     app.post('/camps/copyCommunities/:fromEvent/:toEvent',
-        [/*userRole.isLoggedIn(), userRole.isAdmin()*/],
-        (req, res) => {
-            console.log("############### here ############")
-            log.debug(`EventsAPI copyCommunities ${_.get(req, 'params.event')}`);
-            
+        [userRole.isLoggedIn(), userRole.isAdmin()],
+        (req, res) => {         
             let fromEvent = req.params.fromEvent;
             let toEvent = req.params.toEvent;
-            console.log(`fromEvent: ${fromEvent} - toEvent: ${toEvent}`)
             // sql query to duplicate all previous event camps into new camps with auto generated event id AND update date as current date.
             let sql = `INSERT INTO camps
-                        SELECT created_at, CURDATE() as updated_at, 0 as id, ${toEvent} as event_id, __prototype, camp_name_he, camp_name_en, camp_desc_he, camp_desc_en, type, status, web_published, camp_activity_time, child_friendly, noise_level, public_activity_area_sqm, public_activity_area_desc, support_art, location_comments, camp_location_street, camp_location_street_time, camp_location_area, addinfo_json, main_contact, moop_contact, safety_contact, contact_person_name, contact_person_email, contact_person_phone, accept_families, facebook_page_url, contact_person_id, pre_sale_tickets_quota
+                        SELECT created_at, CURDATE() as updated_at, 0 as id, '${toEvent}' as event_id, __prototype, camp_name_he, camp_name_en, camp_desc_he, camp_desc_en, type, status, web_published, camp_activity_time, child_friendly, noise_level, public_activity_area_sqm, public_activity_area_desc, support_art, location_comments, camp_location_street, camp_location_street_time, camp_location_area, addinfo_json, main_contact, moop_contact, safety_contact, contact_person_name, contact_person_email, contact_person_phone, accept_families, facebook_page_url, contact_person_id, pre_sale_tickets_quota
                         FROM camps 
                         WHERE event_id='${fromEvent}'`;
+
             knex.raw(sql).then(
-                res.send(200)
+                res.status(200).end()
             );
 
         });

--- a/routes/api_events_routes.js
+++ b/routes/api_events_routes.js
@@ -1,6 +1,6 @@
 
 var log = require('../libs/logger')(module);
-const Event = require('../models/event').Event
+const Event = require('../models/event').Event;
 const userRole = require('../libs/user_role');
 const _ = require('lodash')
 /*
@@ -12,8 +12,7 @@ name,
 gate_code,
 gate_status
 */
-var createEvent = function(req) 
-{
+var createEvent = function (req) {
     var new_event = {
         event_id: _.get(req, 'body.event_id'),
         ext_id_event_id: _.get(req, 'body.ext_id_event_id'),
@@ -30,55 +29,55 @@ module.exports = (app, passport) => {
 
     app.get('/events', (req, res) => {
         Event.fetchAll()
-        .then((events) => {
-            res.status(200).json(
-                { 
-                    events: events.toJSON()
-                }
-            )
-        })
-        .catch((err) => {
-            res.status(500).json({
-                error: true,
-                data: {
-                    message: err.message
-                }
+            .then((events) => {
+                res.status(200).json(
+                    {
+                        events: events.toJSON()
+                    }
+                )
+            })
+            .catch((err) => {
+                res.status(500).json({
+                    error: true,
+                    data: {
+                        message: err.message
+                    }
+                });
             });
-        });
     });
 
-    app.post('/events/new', 
-        [userRole.isLoggedIn(), userRole.isAllowNewCamp()],
+    app.post('/events/new',
+        [userRole.isLoggedIn(), userRole.isAdmin()],
         (req, res) => {
             var new_event = createEvent(req);
             Event.forge().save(new_event)
-            .then(res.send(200))
-            .catch((e) => {
-                res.status(500).json({
-                    error: true,
-                    data: {
-                        message: e.message
-                    }
+                .then(res.send(200))
+                .catch((e) => {
+                    res.status(500).json({
+                        error: true,
+                        data: {
+                            message: e.message
+                        }
+                    });
                 });
-            });
-        }); 
+        });
 
-        app.put('/events/update', 
-        [userRole.isLoggedIn(), userRole.isAllowNewCamp()],
+    app.put('/events/update',
+        [userRole.isLoggedIn(), userRole.isAdmin()],
         (req, res) => {
             var new_event = createEvent(req);
             var event_id = new_event.event_id;
-            Event.forge({event_id: event_id}).save(new_event)
-            .then(res.send(200))
-            .catch((e) => {
-                res.status(500).json({
-                    error: true,
-                    data: {
-                        message: e.message
-                    }
+            Event.forge({ event_id: event_id }).save(new_event)
+                .then(res.send(200))
+                .catch((e) => {
+                    res.status(500).json({
+                        error: true,
+                        data: {
+                            message: e.message
+                        }
+                    });
                 });
-            });
-        }); 
+        });
 
     app.get('/events/:event_id',
         [userRole.isLoggedIn()],
@@ -92,13 +91,14 @@ module.exports = (app, passport) => {
                 for (var prop in props) { events.attributes[prop] = props[prop]; }
                 console.log(event);
                 res.json({ event: event });
-            });    
+            });
         });
 
-    app.put('/events/:event/edit', 
-        userRole.isLoggedIn(),
-        (req, res) => {
-            log.debug('EventsAPI edit ' + _.get(req, 'params.event'));
-        });
+        //Deprecated??? (by '/events/update')
+    // app.put('/events/:event/edit',
+    //     userRole.isLoggedIn(), userRole.isAdmin(),
+    //     (req, res) => {
+    //         log.debug('EventsAPI edit ' + _.get(req, 'params.event'));
+    //     });
 
 }

--- a/views/pages/events/edit.jade
+++ b/views/pages/events/edit.jade
@@ -56,7 +56,7 @@ block content
                                     //- Checkboxes
                                     .col-xs-2
                                         div.row
-                                            input(type="checkbox" id='community_camps', dir='ltr', name='community_camps' ng-model='event.addinfo_json.community_camps')
+                                            input(type="checkbox" id='community_camps', dir='ltr', name='community_camps', ng-model='event.addinfo_json.community_camps', ng-disabled='isCommunityCampsCopied')
                                         div.row
                                             input(type="checkbox" id='community_art_installation', dir='ltr', name='community_art_installation' ng-model='event.addinfo_json.community_art_installation')
                                         div.row

--- a/views/pages/events/index.jade
+++ b/views/pages/events/index.jade
@@ -1,7 +1,7 @@
 extends ../../includes/page
 block content
     script.
-        newEvent="true";
+        var newEvent="true";
     .camps.camp_admin_index(ng-app="ngEvents")
         .container.col-md-12
             h1=t(t_prefix+'dash.title')
@@ -96,4 +96,4 @@ block content
                         .modal-footer
                             a(href='./')
                                 button.Btn.Btn__transparent(id='create_camp_close_btn')=t('events:new.close')
-                            button.Btn.Btn__green(id='event_create_save_modal_request', ng-click="sendEvent()")=t('events:new.send_request')           
+                            button.Btn.Btn__green(id='event_create_save_modal_request', ng-click="createEvent()")=t('events:new.send_request')           


### PR DESCRIPTION
Will copy communities ('camps') from former event to new event.

### UI instructions
in '/he/events-admin' page for new \ edit event - setting the communities checkbox button to true will copy camps bases on previous event id into the new \ edited event.
note; after saving the new \ edited event with communities set, the checkbox becomes impossible to uncheck.

------------------------
closes #496 