### PR TITLE
update art installation managers roles

### DIFF
--- a/scripts/update_art_managers_roles.js
+++ b/scripts/update_art_managers_roles.js
@@ -5,9 +5,10 @@ async function updateRoles() {
 
     //load data from csv....
     const managers = [
-        {'email' : 'krisssy193@gmail.com', 'camp_id' : 162},
-        {'email' : 'shoonami@gmail.com','camp_id' : 77},
-        {'email' : 'ittayr@gmail.com', 'camp_id' : 55}
+        { 'camp_id': 222, 'email': 'some.name3@gmail' },
+        { 'camp_id': 111, 'email': 'some.name2@gmail.com ' },
+        { 'camp_id': 333, 'email': 'some.name@gmail.com' }
+        
     ];
     //console.log(emails)
     await Promise.all(managers.map(async manager => {

--- a/scripts/update_art_managers_roles.js
+++ b/scripts/update_art_managers_roles.js
@@ -1,0 +1,38 @@
+let knex = require('../libs/db').knex;
+
+async function updateRoles() {
+
+    //load data from csv....
+    const managers = [
+        {'email' : 'krisssy193@gmail.com', 'camp_id' : 162},
+        {'email' : 'shoonami@gmail.com','camp_id' : 77},
+        {'email' : 'ittayr@gmail.com', 'camp_id' : 55}
+    ];
+    //console.log(emails)
+    await Promise.all(managers.map(async manager => {
+        try {
+            console.log('Extracting user data for' + manager.email)
+            let users = await knex.select('user_id', 'roles', 'email').from('users').where('email', manager.email);
+            if (users.length === 0) {
+                console.log('Could not find ' + manager.email)
+                return;
+            }
+            let user = users[0];
+            console.log(user);
+             
+            let user_roles = user.roles.split(',').filter((x) => x);
+            if (!user_roles.includes('camp_manager')) {
+                user_roles.push('camp_manager');
+                await knex('users').where('email', manager.email).update('roles', user_roles.join(','));
+
+            }
+        }
+        catch (e) {
+            console.log(e)
+        }
+    }));
+    console.log('Finished');
+    process.exit(0);
+}
+
+updateRoles();

--- a/scripts/update_art_managers_roles.js
+++ b/scripts/update_art_managers_roles.js
@@ -1,3 +1,4 @@
+
 let knex = require('../libs/db').knex;
 
 async function updateRoles() {
@@ -19,15 +20,32 @@ async function updateRoles() {
             }
             let user = users[0];
             console.log(user);
-             
+            let manager_user_id = user.user_id; 
             let user_roles = user.roles.split(',').filter((x) => x);
             if (!user_roles.includes('camp_manager')) {
                 user_roles.push('camp_manager');
                 await knex('users').where('email', manager.email).update('roles', user_roles.join(','));
 
             }
+            // set as main contact
+            let found_camps = await knex('camps').select('id', 'main_contact').where('id', manager.camp_id);
+            if (found_camps.length === 0) {
+                console.log('Could not camp ' + manager.email)
+                return;
+            }
+            let camp = found_camps[0];
+            if (!camp.main_contact) {
+                //set main contact
+                console.log('Setting camp ' + manager.camp_id + ' main contact to ' + manager_user_id + ' ... ')                
+                await knex('camps').where('id', manager.camp_id).update('main_contact', manager_user_id);
+                console.log('Success!!!')
+            }
+            else {
+                console.log('Camp ' + manager.camp_id + ' already has a main contact defined')
+            }
         }
         catch (e) {
+            console.log('error')
             console.log(e)
         }
     }));


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
We need to update the roles of art installations to _camp_manages_
### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
* script that iterates over the emails and append the came_manage role  to their existing ones 
* also need to set them as main_contact in the camps table
### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->


### Testing Done
<!-- How have you confirmed this feature works? -->

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Spark dependencies -->
<!-- 3. Make sure your code is compliant with the [Spark styleguide](CONTRIBUTING.md) -->
<!-- 4. If your PR fixes an issue, reference that issue -->
<!-- 5. If your PR has lots of commits, **rebase** first -->
<!-- 6. Run `npm test` before submitting your PR -->
