### PR TITLE
User tests From Pages View

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -91,6 +91,9 @@ OPBEAT_APP_ID=""
 OPBEAT_ORGANIZATION_ID=""
 OPBEAT_SECRET_TOKEN=""
 
+#supported Languges
+LANGUAGES=["en","he"]
+
 # optional - devops / slack / travis / deployment
 # better to export these variables as they might be used from shell scripts
 # if you have ssh access to the staging environment you can get the values from there (/opt/spark/.env)

--- a/routes/pages/camps_routes.js
+++ b/routes/pages/camps_routes.js
@@ -303,7 +303,7 @@ var __render_camp = function (camp, req, res) {
     });
 
     // art admin management panel
-    router.get('/art-admin/:cardId*?', userRole.isLoggedIn(), (req, res) => {
+    router.get('/art-admin/:cardId*?', userRole.isAdmin(), (req, res) => {
         req.breadcrumbs([{
             name: 'breadcrumbs.home',
             url: '/' + req.params.lng + '/home'
@@ -329,7 +329,7 @@ var __render_camp = function (camp, req, res) {
         }
     });
     // art admin management panel
-    router.get('/prod-admin/:cardId*?', userRole.isLoggedIn(), (req, res) => {
+    router.get('/prod-admin/:cardId*?', userRole.isAdmin(), (req, res) => {
         req.breadcrumbs([{
             name: 'breadcrumbs.home',
             url: '/' + req.params.lng + '/home'

--- a/routes/pages/npo_admin_routes.js
+++ b/routes/pages/npo_admin_routes.js
@@ -24,7 +24,7 @@ let getNextMemberNumber = () => {
 };
 
 // TODO protect by npm_admin role
-router.get('/', userRole.isLoggedIn(), function (req, res) {
+router.get('/', userRole.isAdmin(), function (req, res) {
     res.render('pages/npo/admin');
 });
 

--- a/tests/pages/0_init.test.js
+++ b/tests/pages/0_init.test.js
@@ -1,0 +1,43 @@
+require("dotenv").config();
+const agent = require("supertest").agent(require("../../app"));
+const languages = process.env.languages || ["en", "he"];
+const User = require("../../models/user").User;
+
+// const ADMIN_USER_EMAIL = "omerp@websplanet.com";
+// const ADMIN_USER_PASSWORD = "123456";
+const ADMIN_USER_EMAIL = "aaa";
+const ADMIN_USER_PASSWORD = "123456";
+
+const users = [
+    {
+        email: "test_admin",
+        password: "123456",
+        roles: "admin"
+    },
+    {
+        email: "test_camp_manager",
+        password: "123456",
+        roles: "camp_manager"
+    },
+    {
+        email: "test_user",
+        password: "123456",
+        roles: ""
+    }
+];
+
+(async () => {
+    users.forEach(async (user) => {
+        var newUser = new User({
+            email: user.email,
+            validated: true,
+            roles: user.roles
+        });
+        newUser.generateHash(user.password);
+        await newUser.save();
+    });
+})();
+
+module.exports.Admin = users[0]; 
+module.exports.campAdmin = users[1];
+module.exports.user = users[2];

--- a/tests/pages/admin_pages.test.js
+++ b/tests/pages/admin_pages.test.js
@@ -1,0 +1,202 @@
+require("dotenv").config();
+const agent = require("supertest").agent(require("../../app"));
+const languages = process.env.languages || ["en", "he"];
+const User = require("../../models/user").User;
+const testUser = require("./0_init.test").Admin;
+
+describe("Admin Pages", function() {
+    this.timeout(20000);
+    before(async () => {
+        await agent
+            .post(`/${languages[0]}/login`)
+            .send({
+                email: testUser.email,
+                password: testUser.password
+            })
+            .expect(302);
+    });
+
+    it(`home page should show in ${languages}`, () => {
+        const page = "home";
+        const promises = [];
+        let regex;
+        for (let i = 0; i < languages.length; i++) {
+            switch (languages[i]) {
+                case "en":
+                    regex = /Welcome Home/;
+                    break;
+                case "he":
+                    regex = /הביתה,/;
+                    break;
+                default:
+                    break;
+            }
+            promises[i] = agent
+                .get(`/${languages[i]}/${page}`)
+                .expect(200)
+                .expect(regex);
+        }
+        return Promise.all(promises);
+    });
+
+    it(`camps page should show in ${languages}`, () => {
+        const page = "camps";
+        const promises = [];
+        let regex;
+        for (let i = 0; i < languages.length; i++) {
+            switch (languages[i]) {
+                case "en":
+                    regex = /Camps/;
+                    break;
+                case "he":
+                    regex = /מחנות נושא ואמנות/;
+                    break;
+                default:
+                    break;
+            }
+            promises[i] = agent
+                .get(`/${languages[i]}/${page}`)
+                .expect(200)
+                .expect(regex);
+        }
+        return Promise.all(promises);
+    });
+
+    it(`npo page should show in ${languages}`, () => {
+        const page = "npo";
+        const promises = [];
+        let regex;
+        for (let i = 0; i < languages.length; i++) {
+            switch (languages[i]) {
+                case "en":
+                    regex = /Midburn Association/;
+                    break;
+                case "he":
+                    regex = /עמותת מידברן/;
+                    break;
+                default:
+                    break;
+            }
+            promises[i] = agent
+                .get(`/${languages[i]}/${page}`)
+                .expect(200)
+                .expect(regex);
+        }
+        return Promise.all(promises);
+    });
+
+    it(`gate page should show in ${languages}`, () => {
+        const page = "gate";
+        const promises = [];
+        let regex;
+        for (let i = 0; i < languages.length; i++) {
+            switch (languages[i]) {
+                case "en":
+                    regex = /Gate/;
+                    break;
+                case "he":
+                    regex = /שער/;
+                    break;
+                default:
+                    break;
+            }
+            promises[i] = agent
+                .get(`/${languages[i]}/${page}`)
+                .expect(200)
+                .expect(regex);
+        }
+        return Promise.all(promises);
+    });
+
+    it(`art-admin page should show in ${languages}`, () => {
+        const page = "art-admin";
+        const promises = [];
+        let regex;
+        for (let i = 0; i < languages.length; i++) {
+            switch (languages[i]) {
+                case "en":
+                    regex = /art/;
+                    break;
+                case "he":
+                    regex = /מיצבים/;
+                    break;
+                default:
+                    break;
+            }
+            promises[i] = agent
+                .get(`/${languages[i]}/${page}`)
+                .expect(200)
+                .expect(regex);
+        }
+        return Promise.all(promises);
+    });
+
+    it(`prod-admin page should show in ${languages}`, () => {
+        const page = "prod-admin";
+        const promises = [];
+        let regex;
+        for (let i = 0; i < languages.length; i++) {
+            switch (languages[i]) {
+                case "en":
+                    regex = /prod/;
+                    break;
+                case "he":
+                    regex = /ניהול מחלקות הפקה/;
+                    break;
+                default:
+                    break;
+            }
+            promises[i] = agent
+                .get(`/${languages[i]}/${page}`)
+                .expect(200)
+                .expect(regex);
+        }
+        return Promise.all(promises);
+    });
+
+    it(`npo-admin page should show in ${languages}`, () => {
+        const page = "npo-admin";
+        const promises = [];
+        let regex;
+        for (let i = 0; i < languages.length; i++) {
+            switch (languages[i]) {
+                case "en":
+                    regex = /npo-admin/;
+                    break;
+                case "he":
+                    regex = /עמותת מידברן/;
+                    break;
+                default:
+                    break;
+            }
+            promises[i] = agent
+                .get(`/${languages[i]}/${page}`)
+                .expect(200)
+                .expect(regex);
+        }
+        return Promise.all(promises);
+    });
+
+    it(`events-admin page should show in ${languages}`, () => {
+        const page = "events-admin";
+        const promises = [];
+        let regex;
+        for (let i = 0; i < languages.length; i++) {
+            switch (languages[i]) {
+                case "en":
+                    regex = /Events/;
+                    break;
+                case "he":
+                    regex = /אירועים/;
+                    break;
+                default:
+                    break;
+            }
+            promises[i] = agent
+                .get(`/${languages[i]}/${page}`)
+                .expect(200)
+                .expect(regex);
+        }
+        return Promise.all(promises);
+    });
+});

--- a/tests/pages/camp_manager_pages.test.js
+++ b/tests/pages/camp_manager_pages.test.js
@@ -1,0 +1,148 @@
+require("dotenv").config();
+const agent = require("supertest").agent(require("../../app"));
+const languages = process.env.languages || ["en", "he"]
+const User = require("../../models/user").User;
+const testUser = require("./0_init.test").campAdmin;
+
+describe("Camp_Admin Pages", function() {
+    this.timeout(20000);
+    before(async () => {
+        await agent
+            .post(`/${languages[0]}/login`)
+            .send({
+                email: testUser.email,
+                password: testUser.password
+            })
+            .expect(302);
+    });
+
+    it(`home page should show in ${languages}`, () => {
+        const page = "home";
+        const promises = [];
+        let regex;
+        for (let i = 0; i < languages.length; i++) {
+            switch (languages[i]) {
+                case 'en':
+                    regex = /Welcome Home/;
+                    break;
+                case 'he':
+                    regex = /הביתה,/;
+                    break;
+                default:
+                    break;
+            }
+            promises[i] = agent
+                .get(`/${languages[i]}/${page}`)
+                .expect(200)
+                .expect(regex);
+        }
+        return Promise.all(promises);
+    });
+
+    it(`camps page should show in ${languages}`, () => {
+        const page = "camps";
+        const promises = [];
+        let regex;
+        for (let i = 0; i < languages.length; i++) {
+            switch (languages[i]) {
+                case 'en':
+                    regex = /Camps/;
+                    break;
+                case 'he':
+                    regex = /מחנות נושא ואמנות/;
+                    break;
+                default:
+                    break;
+            }
+            promises[i] = agent
+                .get(`/${languages[i]}/${page}`)
+                .expect(200)
+                .expect(regex);
+        }
+        return Promise.all(promises);
+    });
+
+    it(`npo page should show in ${languages}`, () => {
+        const page = "npo";
+        const promises = [];
+        let regex;
+        for (let i = 0; i < languages.length; i++) {
+            switch (languages[i]) {
+                case 'en':
+                    regex = /Midburn Association/;
+                    break;
+                case 'he':
+                    regex = /עמותת מידברן/;
+                    break;
+                default:
+                    break;
+            }
+            promises[i] = agent
+                .get(`/${languages[i]}/${page}`)
+                .expect(200)
+                .expect(regex);
+        }
+        return Promise.all(promises);
+    });
+
+    it(`gate page forbidden ${languages}`, () => {
+        const page = "gate";
+        const promises = [];
+        let regex;
+        for (let i = 0; i < languages.length; i++) {
+            promises[i] = agent
+                .get(`/${languages[i]}/${page}`)
+                .expect(403)
+        }
+        return Promise.all(promises);
+    });
+
+    it(`art-admin page forbidden ${languages}`, () => {
+        const page = "art-admin";
+        const promises = [];
+        let regex;
+        for (let i = 0; i < languages.length; i++) {
+            promises[i] = agent
+                .get(`/${languages[i]}/${page}`)
+                .expect(403);
+        }
+        return Promise.all(promises);
+    });
+
+    it(`prod-admin page forbidden ${languages}`, () => {
+        const page = "prod-admin";
+        const promises = [];
+        let regex;
+        for (let i = 0; i < languages.length; i++) {
+            promises[i] = agent
+                .get(`/${languages[i]}/${page}`)
+                .expect(403);
+        }
+        return Promise.all(promises);
+    });
+
+    it(`npo-admin page forbidden ${languages}`, () => {
+        const page = "npo-admin";
+        const promises = [];
+        let regex;
+        for (let i = 0; i < languages.length; i++) {
+            promises[i] = agent
+                .get(`/${languages[i]}/${page}`)
+                .expect(403);
+        }
+        return Promise.all(promises);
+    });
+
+    it(`events-admin page forbidden ${languages}`, () => {
+        const page = "events-admin";
+        const promises = [];
+        let regex;
+        for (let i = 0; i < languages.length; i++) {
+            promises[i] = agent
+                .get(`/${languages[i]}/${page}`)
+                .expect(403);
+        }
+        return Promise.all(promises);
+    });
+
+});

--- a/tests/pages/user_pages.test.js
+++ b/tests/pages/user_pages.test.js
@@ -1,0 +1,147 @@
+require("dotenv").config();
+const agent = require("supertest").agent(require("../../app"));
+const languages = process.env.languages || ["en", "he"];
+const User = require("../../models/user").User;
+const testUser = require("./0_init.test").user;
+
+describe("user Pages", function() {
+    this.timeout(20000);
+    before(async () => {
+        await agent
+            .post(`/${languages[0]}/login`)
+            .send({
+                email: testUser.email,
+                password: testUser.password
+            })
+            .expect(302);
+    });
+
+    it(`home page should show in ${languages}`, () => {
+        const page = "home";
+        const promises = [];
+        let regex;
+        for (let i = 0; i < languages.length; i++) {
+            switch (languages[i]) {
+                case "en":
+                    regex = /Welcome Home/;
+                    break;
+                case "he":
+                    regex = /הביתה,/;
+                    break;
+                default:
+                    break;
+            }
+            promises[i] = agent
+                .get(`/${languages[i]}/${page}`)
+                .expect(200)
+                .expect(regex);
+        }
+        return Promise.all(promises);
+    });
+
+    it(`camps page should show in ${languages}`, () => {
+        const page = "camps";
+        const promises = [];
+        let regex;
+        for (let i = 0; i < languages.length; i++) {
+            switch (languages[i]) {
+                case "en":
+                    regex = /Camps/;
+                    break;
+                case "he":
+                    regex = /מחנות נושא ואמנות/;
+                    break;
+                default:
+                    break;
+            }
+            promises[i] = agent
+                .get(`/${languages[i]}/${page}`)
+                .expect(200)
+                .expect(regex);
+        }
+        return Promise.all(promises);
+    });
+
+    it(`npo page should show in ${languages}`, () => {
+        const page = "npo";
+        const promises = [];
+        let regex;
+        for (let i = 0; i < languages.length; i++) {
+            switch (languages[i]) {
+                case "en":
+                    regex = /Midburn Association/;
+                    break;
+                case "he":
+                    regex = /עמותת מידברן/;
+                    break;
+                default:
+                    break;
+            }
+            promises[i] = agent
+                .get(`/${languages[i]}/${page}`)
+                .expect(200)
+                .expect(regex);
+        }
+        return Promise.all(promises);
+    });
+
+    it(`gate page forbidden ${languages}`, () => {
+        const page = "gate";
+        const promises = [];
+        let regex;
+        for (let i = 0; i < languages.length; i++) {
+            promises[i] = agent
+                .get(`/${languages[i]}/${page}`)
+                .expect(403)
+        }
+        return Promise.all(promises);
+    });
+
+    it(`art-admin page forbidden ${languages}`, () => {
+        const page = "art-admin";
+        const promises = [];
+        let regex;
+        for (let i = 0; i < languages.length; i++) {
+            promises[i] = agent
+                .get(`/${languages[i]}/${page}`)
+                .expect(403);
+        }
+        return Promise.all(promises);
+    });
+
+    it(`prod-admin page forbidden ${languages}`, () => {
+        const page = "prod-admin";
+        const promises = [];
+        let regex;
+        for (let i = 0; i < languages.length; i++) {
+            promises[i] = agent
+                .get(`/${languages[i]}/${page}`)
+                .expect(403);
+        }
+        return Promise.all(promises);
+    });
+
+    it(`npo-admin page forbidden ${languages}`, () => {
+        const page = "npo-admin";
+        const promises = [];
+        let regex;
+        for (let i = 0; i < languages.length; i++) {
+            promises[i] = agent
+                .get(`/${languages[i]}/${page}`)
+                .expect(403);
+        }
+        return Promise.all(promises);
+    });
+
+    it(`events-admin page forbidden ${languages}`, () => {
+        const page = "events-admin";
+        const promises = [];
+        let regex;
+        for (let i = 0; i < languages.length; i++) {
+            promises[i] = agent
+                .get(`/${languages[i]}/${page}`)
+                .expect(403);
+        }
+        return Promise.all(promises);
+    });
+});


### PR DESCRIPTION
##Description
These unit test will log in with different roles (admin, camp_admin, user) and will check that access to each page if allowed \ forbidden. The tests are run for each supported language based on .env or defaults to 'en' & 'he'.

in each loaded page, a regex test will check for specific text values, this will enable us to check if the page crushes (not showing the title for example, instead showing the error page).

##Farther Work (opening issues)
* Add .end languages in all environments (should be a table like languages="['en', 'he']" #659 
* fix Engilsh pages locals, and the update the test with the correct title (currently for broken page the test will "find" the file name instead which will not help in preventing showing error page). #658 
* might be possible to move the 0_init functions into the mocha before(), inside each file... I played around with it with no success.