### PR TITLE
edit camp personnel final fixes #609

### DIFF
--- a/public/scripts/camps.js
+++ b/public/scripts/camps.js
@@ -118,24 +118,25 @@ $(function () {
 //     }
 // }
 
-function extractCampData() {
+function extractCampData(isNew) {
     var activity_time = fetchAllCheckboxValues('camp_activity_time');
     var type = fetchAllCheckboxValues('camp_type');
+    const loggedInUser = $('#logged_user_id').val();
 
     return {
         camp_name_he: $('#camp_name_he').val() || 'camp' + (+new Date()),
         camp_name_en: $('#camp_name_en').val(),
         camp_desc_he: $('#camp_desc_he').val() || '',
         camp_desc_en: $('#camp_desc_en').val() || '',
-        contact_person_id: $('#camp_contact_person_id option:selected').val() || '',
+        contact_person_id: isNew ? loggedInUser : $('#camp_contact_person_id option:selected').val() || '',
         facebook_page_url: $('#camp_facebook_page_url').val() || '',
         contact_person_name: $('#camp_contact_person_name').val() || '',
         contact_person_email: $('#camp_contact_person_email').val() || '',
         contact_person_phone: $('#camp_contact_person_phone').val() || '',
         accept_families: $('#camp_accept_families:checked').length,
-        main_contact: $('#camp_main_contact option:selected').val() || '',
-        moop_contact: $('#camp_moop_contact option:selected').val() || '',
-        safety_contact: $('#camp_safety_contact option:selected').val() || '',
+        main_contact: isNew ? loggedInUser : $('#camp_main_contact option:selected').val() || '',
+        moop_contact: isNew ? loggedInUser : $('#camp_moop_contact option:selected').val() || '',
+        safety_contact: isNew ? loggedInUser : $('#camp_safety_contact option:selected').val() || '',
         type: type || '',
         camp_status: $('#camp_status option:selected').val() || '',
         camp_activity_time: activity_time || '',
@@ -159,7 +160,7 @@ function extractCampData() {
  */
 $('#camp_edit_save').click(function () {
     var camp_id = $('#camp_edit_camp_id').val();
-    var camp_data = extractCampData();
+    var camp_data = extractCampData(true);
     var lang = document.getElementById('meta__lang').value;
 
     $.ajax({

--- a/public/scripts/controllers/camp_edit.js
+++ b/public/scripts/controllers/camp_edit.js
@@ -1,11 +1,5 @@
 var angular_getMembers = function ($http, $scope, camp_id) {
-    if (camp_id === 'new') {
-        $http.get('/users').then((res) => {
-            $scope.members = [];
-            $scope.approved_members = res.data.users;
-        });
-    } else {
-        $http.get(`/camps/${camp_id}/members`).then((res) => {
+    $http.get(`/camps/${camp_id}/members`).then((res) => {
             var members = res.data.members;
             var _members = [];
             var approved_members = [];
@@ -41,7 +35,7 @@ var angular_getMembers = function ($http, $scope, camp_id) {
             $scope.total_in_event = total_in_event;
         });
     }
-}
+    
 var angular_updateUser = function ($http, $scope, action_type, user_rec) {
     var camp_id = user_rec.camp_id;
     var user_name = user_rec.user_name;

--- a/public/scripts/events.js
+++ b/public/scripts/events.js
@@ -118,7 +118,7 @@ $(function () {
 //     }
 // }
 
-function extractCampData() {
+function extractEventsCampData() {
     var activity_time = fetchAllCheckboxValues('camp_activity_time');
     var type = fetchAllCheckboxValues('camp_type');
 

--- a/public/scripts/events.js
+++ b/public/scripts/events.js
@@ -159,7 +159,7 @@ function extractEventsCampData() {
  */
 $('#camp_edit_save').click(function () {
     var camp_id = $('#camp_edit_camp_id').val();
-    var camp_data = extractCampData();
+    var camp_data = extractEventsCampData();
     var lang = document.getElementById('meta__lang').value;
 
     $.ajax({

--- a/views/pages/camps/camp.jade
+++ b/views/pages/camps/camp.jade
@@ -74,7 +74,7 @@ block content
                                     h6 #{t('camps:camps.name')}:
                                         span.contact_person_name #{main_contact.name}
                                     h6 #{t('camps:camps.phone')}:
-                                        span.contact_person_phone #{main_contact.cell_phone}
+                                        span.contact_person_phone #{main_contact.cell_phone ? main_contact.cell_phone : camp.contact_person_phone}
                                     h6 #{t('camps:camps.email')}:
                                         span.contact_person_email #{main_contact.email}
                                     //- a.details.hidden(href='/users/#{camp.main_contact}')=t('camps:camps.more_info')
@@ -88,7 +88,7 @@ block content
                                     h6 #{t('camps:camps.name')}:
                                         span.contact_person_name #{moop_contact.name}
                                     h6 #{t('camps:camps.phone')}:
-                                        span.contact_person_phone #{moop_contact.cell_phone}
+                                        span.contact_person_phone #{moop_contact.cell_phone ? moop_contact.cell_phone : camp.contact_person_phone}
                                     h6 #{t('camps:camps.email')}:
                                         span.contact_person_email #{moop_contact.email}
                                     //- a.details.hidden(href='/users/#{camp.moop_contact}')=t('camps:camps.more_info')
@@ -102,7 +102,7 @@ block content
                                     h6 #{t('camps:camps.name')}:
                                         span.contact_person_name #{safety_contact.name}
                                     h6 #{t('camps:camps.phone')}:
-                                        span.contact_person_phone #{safety_contact.cell_phone}
+                                        span.contact_person_phone #{safety_contact.cell_phone ? safety_contact.cell_phone : camp.contact_person_phone}
                                     h6 #{t('camps:camps.email')}:
                                         span.contact_person_email #{safety_contact.email}
                                     //- a.details.hidden(href='/users/#{camp.safety_contact}')=t('camps:camps.more_info')

--- a/views/pages/camps/edit.jade
+++ b/views/pages/camps/edit.jade
@@ -10,6 +10,7 @@ block content
     input.hidden.meta(id='meta__camp_name_en', value='#{camp.camp_name_en}')
     input.hidden.meta(id='meta__camp_id', value='#{camp.id}')
     input.hidden.meta(id='meta__grouptype', value='#{camp.__prototype}')
+    input.hidden.meta(id='logged_user_id', value='#{user.attributes.user_id}')
     .camps.camp_edit(ng-app="ngCamps", ng-controller="campEditController")
 
         .heading.card.card__shad
@@ -76,15 +77,15 @@ block content
                                     .col-md-4
                                         .col-xs-12
                                             label(for='camp_contact_person_name')=t('camps:edit.contact_person_name')
-                                            input.form-control(id='camp_contact_person_name', name='contact_person_name', value=(isNew ? '' : '#{camp.contact_person_name}'))
+                                            input.form-control(id='camp_contact_person_name', name='contact_person_name', value=(isNew ? '#{user.fullName}' : '#{camp.contact_person_name}'))
                                     .col-md-4
                                         .col-xs-12
                                             label(for='camp_contact_person_email')=t('camps:edit.contact_person_email')
-                                            input.form-control(id='camp_contact_person_email', name='contact_person_email', value=(isNew ? '' : '#{camp.contact_person_email}'))
+                                            input.form-control(id='camp_contact_person_email', name='contact_person_email', value=(isNew ? '#{user.attributes.email}' : '#{camp.contact_person_email}'))
                                     .col-md-4
                                         .col-xs-12
                                             label(for='camp_contact_person_phone')=t('camps:edit.contact_person_phone')
-                                            input.form-control(id='camp_contact_person_phone', name='contact_person_phone', value=(isNew ? '' : '#{camp.contact_person_phone}'))
+                                            input.form-control(id='camp_contact_person_phone', name='contact_person_phone', value=(isNew ? user.attributes.cell_phone ? '#{user.attributes.cell_phone}' : '' : '#{camp.contact_person_phone}'))
                                 .row
                                     .col-md-4
                                         .col-xs-12
@@ -108,27 +109,28 @@ block content
                                                     button.Btn.Btn__sm.bg__teal(id='camp_edit_unpublish')=t('camps:edit.unpublish')
                                                 else
                                                     span.badge.bg__red=t('camps:camps.no')
-                h4=t('camps:edit.contact_title')
-                .camp-leaders.panel
-                    .panel-body
-                        .personnel
-                            .col-md-4
-                                .col-xs-12
-                                    label(for='camp_main_contact')=t('camps:edit.main_contact')
-                                    select.form-control.form__input--important(id='camp_main_contact', name='main_contact')
-                                        option(ng-repeat="member in approved_members", ng-selected="member.user_id == #{camp.main_contact}", value="{{member.user_id}}") {{ member.name}} ({{ member.email }})
-                            if (isCamp)
-                                .col-md-4
-                                    .col-xs-12
-                                        label(for='camp_moop_contact')=t('camps:edit.moop_contact')
-                                        select.form-control(id='camp_moop_contact', name='moop_contact')
-                                            option(ng-repeat="member in approved_members", ng-selected="member.user_id == #{camp.moop_contact}", value="{{member.user_id}}") {{ member.name}} ({{ member.email }})
-                                .col-md-4
-                                    .col-xs-12
-                                        label(for='camp_safety_contact')=t('camps:edit.safety_contact')
-                                        select.form-control(id='camp_safety_contact', name='safety_contact')
-                                            option(ng-repeat="member in approved_members", ng-selected="member.user_id == #{camp.safety_contact}", value="{{member.user_id}}") {{ member.name}} ({{ member.email }})
                 if (!isNew)
+                    h4=t('camps:edit.contact_title')
+                    .camp-leaders.panel
+                        .panel-body
+                            .personnel
+                                .col-md-4
+                                    .col-xs-12
+                                        label(for='camp_main_contact')=t('camps:edit.main_contact')
+                                        select.form-control.form__input--important(id='camp_main_contact', name='main_contact')
+                                            option(ng-repeat="member in approved_members", ng-selected="member.user_id == #{camp.main_contact}", value="{{member.user_id}}") {{ member.name}} ({{ member.email }})
+                                if (isCamp)
+                                    .col-md-4
+                                        .col-xs-12
+                                            label(for='camp_moop_contact')=t('camps:edit.moop_contact')
+                                            select.form-control(id='camp_moop_contact', name='moop_contact')
+                                                option(ng-repeat="member in approved_members", ng-selected="member.user_id == #{camp.moop_contact}", value="{{member.user_id}}") {{ member.name}} ({{ member.email }})
+                                    .col-md-4
+                                        .col-xs-12
+                                            label(for='camp_safety_contact')=t('camps:edit.safety_contact')
+                                            select.form-control(id='camp_safety_contact', name='safety_contact')
+                                                option(ng-repeat="member in approved_members", ng-selected="member.user_id == #{camp.safety_contact}", value="{{member.user_id}}") {{ member.name}} ({{ member.email }})
+                
                     h4=t(t_prefix+'edit.add_info')
                     .camp-details.panel
                         .panel-body


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->

### Proposed solution
Don't return users table when camp is new
Hide camp personnel selection when camp is new
in camp & edit view:
with interpolation show current logged in user's details as camp manager;
also show these details on other roles in camp (moop, safety and main contacts)

### Tradeoffs
in pages/camps/partials/members_table.jade
if I use
td {{member.cell_phone ? member.cell_phone : '#{camp.contact_person_phone}'}}
instead of:
td {{member.cell_phone}}
to present members' phone if NE in current user OR filled out in main_contact in edit.jade

if we edit camp members_table.jade will show up fine, but if we go to camps-admin page member_table.jade would not recognize entity 'camp'

### Testing Done
created a new camp, saw that camp personnel are with current users' details;
in edit camp view details should appear; if current users' phone number is missing get number from filled details.
verify details in camp overview.