### PR TITLE
Camp manager file upload permission workaround 

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "this is part of the deployment proess, so it is important to update the version number",
     "version name corresponds to the github release name / tag name - https://github.com/Midburn/Spark/releases"
   ],
-  "version": "2.10.19",
+  "version": "2.10.20",
   "private": true,
   "scripts": {
     "postinstall": "cd public; npm install",

--- a/routes/api/api_camps_routes.js
+++ b/routes/api/api_camps_routes.js
@@ -649,7 +649,7 @@ module.exports = (app, passport) => {
 
     const __can_edit_camp_file = (user) => {
         // If the user is an Admin, he can edit files without constraints
-        if (user.isAdmin || user.isCampManager) return true;
+        // if (user.isAdmin || user.isCampManager) return true;
 
         //const now = new Date()
         //const startDate = new Date(camp_files_config.upload_start_date)
@@ -660,8 +660,9 @@ module.exports = (app, passport) => {
         //    return true
         //}
 
-        return false
+        //return false
 
+        return true;
     }
 
     const __prepare_camp_files = (camp, user) => {


### PR DESCRIPTION
removing constraint on file upload for now because many camp managers don;t have camp manager roles 