### PR TITLE
fix selector content fixes #652

### DIFF
--- a/views/pages/camps/index_admin.jade
+++ b/views/pages/camps/index_admin.jade
@@ -56,7 +56,7 @@ block content
                             //- th.admin-edit=t(t_prefix+'stats.edit')
                             //- th.admin-remove=t(t_prefix+'stats.remove')
                     tbody
-                        tr(ng-repeat="camp in camps | filter: searchCamp | orderBy: orderCamps")
+                        tr(ng-repeat="camp in camps | filter:{__prototype: 'art_installation'} | orderBy: orderCamps")
                             td {{ camp.id }}
                             td 
                                 a(ng-href=`/${language}/camps/{{camp.id}}`)

--- a/views/pages/camps/index_admin.jade
+++ b/views/pages/camps/index_admin.jade
@@ -56,11 +56,8 @@ block content
                             //- th.admin-edit=t(t_prefix+'stats.edit')
                             //- th.admin-remove=t(t_prefix+'stats.remove')
                     tbody
-<<<<<<< HEAD
+
                         tr(ng-repeat="camp in camps | filter: searchCamp | filter: {__prototype: 'art_installation'} | orderBy: orderCamps")
-=======
-                        tr(ng-repeat="camp in camps | filter:{__prototype: 'art_installation'} | orderBy: orderCamps")
->>>>>>> 432c896e2552e0416fdc3b5a7a883de805dc9c63
                             td {{ camp.id }}
                             td 
                                 a(ng-href=`/${language}/camps/{{camp.id}}`)

--- a/views/pages/camps/index_admin.jade
+++ b/views/pages/camps/index_admin.jade
@@ -56,7 +56,7 @@ block content
                             //- th.admin-edit=t(t_prefix+'stats.edit')
                             //- th.admin-remove=t(t_prefix+'stats.remove')
                     tbody
-                        tr(ng-repeat="camp in camps | filter: searchCamp | orderBy: orderCamps")
+                        tr(ng-repeat="camp in camps | filter: searchCamp | filter: {__prototype: 'art_installation'} | orderBy: orderCamps")
                             td {{ camp.id }}
                             td 
                                 a(ng-href=`/${language}/camps/{{camp.id}}`)

--- a/views/pages/camps/index_user.jade
+++ b/views/pages/camps/index_user.jade
@@ -17,12 +17,12 @@ block content
                                     label=t('camps:new.name_en')
                                     input.hidden(id='join_camp_request_join_user_id', type='hidden', value='#{user.attributes.user_id}')
                                     select(type="text", id='join_camp_request_camp_id', class="form-control", name="camp_name_en", autofocus="true", required)
-                                        option(ng-repeat="camp in camps", value="{{camp.id}}") {{camp.camp_name_en}}
+                                        option(ng-repeat="camp in camps | filter:{__prototype: '!art_installation'}", value="{{camp.id}}") {{camp.camp_name_en}}
                                 else
                                     label=t('camps:new.name_he')
                                     input.hidden(id='join_camp_request_join_user_id', type='hidden', value='#{user.attributes.user_id}')
                                     select(type="text", id='join_camp_request_camp_id', class="form-control", name="camp_name_he", autofocus="true", required)
-                                        option(ng-repeat="camp in camps", value="{{camp.id}}") {{camp.camp_name_he}}
+                                        option(ng-repeat="camp in camps | filter:{__prototype: '!art_installation'}", value="{{camp.id}}") {{camp.camp_name_he}}
                             .col-sm-4.col-xs-12
                                 a.Btn.Btn__green.Btn__inline(ng-click="joinRequest()", role='button')=t('camps:join.request')
                     else


### PR DESCRIPTION
### Proposed solution
in selector, filter camps for views.
select camp that are and aren't art_installations

### Tradeoffs
none

### Testing Done
go to db and find an art_installation camp according to midburn year.
this item should show for the selector in /art-admin and not in /camps