### PR TITLE
Fixes #655 Camps name sort

### DIFF
--- a/views/pages/camps/index_user.jade
+++ b/views/pages/camps/index_user.jade
@@ -17,12 +17,12 @@ block content
                                     label=t('camps:new.name_en')
                                     input.hidden(id='join_camp_request_join_user_id', type='hidden', value='#{user.attributes.user_id}')
                                     select(type="text", id='join_camp_request_camp_id', class="form-control", name="camp_name_en", autofocus="true", required)
-                                        option(ng-repeat="camp in camps", value="{{camp.id}}") {{camp.camp_name_en}}
+                                        option(ng-repeat="camp in camps | orderBy:'camp_name_en'", value="{{camp.id}}") {{camp.camp_name_en}}
                                 else
                                     label=t('camps:new.name_he')
                                     input.hidden(id='join_camp_request_join_user_id', type='hidden', value='#{user.attributes.user_id}')
                                     select(type="text", id='join_camp_request_camp_id', class="form-control", name="camp_name_he", autofocus="true", required)
-                                        option(ng-repeat="camp in camps", value="{{camp.id}}") {{camp.camp_name_he}}
+                                        option(ng-repeat="camp in camps| orderBy:'camp_name_he'", value="{{camp.id}}") {{camp.camp_name_he}}
                             .col-sm-4.col-xs-12
                                 a.Btn.Btn__green.Btn__inline(ng-click="joinRequest()", role='button')=t('camps:join.request')
                     else
@@ -42,7 +42,7 @@ block content
                               a.Btn.Btn__sm(ng-click='approveRequest()' ng-if="camp.status=='pending_mgr'")=t('camps:pending.approve_request')
                               a.Btn.Btn__sm(ng-click='cancelRequest()')=t('camps:pending.cancel_request')
                               //- a.Btn.Btn__sm(ng-click='resendRequest()') Resend request
-                          
+
         // Camp join request modal
         .modal.fade(id='join_camp_request_modal', tabindex='-1', role='dialog')
             .modal-dialog.card.card__padding--even.card__shad(role='document')


### PR DESCRIPTION
### Proposed solution
Sorting the camps list using angular's orderBy filter

### Testing Done
It was tested locally only, but the change is simple and not risky.
