### PR TITLE
continuous deployment for api-refactor-feb-2018

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   matrix:
   - DEPLOY_ENVIRONMENT=staging DEPLOY_BRANCH=master
   - DEPLOY_ENVIRONMENT=production DEPLOY_TAGS=true
+  - DEPLOY_ENVIRONMENT=sparktesting DEPLOY_BRANCH=api-refactor-feb-2018
   - ""
 cache:
   directories:


### PR DESCRIPTION
Enable continuous deployment from branch api-refactor-feb-2018 to sparktesting environment available at https://spark.testing.midburn.org/

You can modify the DB export it uses by editing the [sparktesting environment values](https://github.com/Midburn/midburn-k8s/blob/master/environments/sparktesting/values.yaml#L20)