### PR TITLE
[README] fix travis badge and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/Midburn/Spark.svg?branch=master)](https://travis-ci.org/Midburn/Spark)
+[![Build Status](https://travis-ci.org/Midburn/spark.svg?branch=master)](https://travis-ci.org/Midburn/spark)
 [![Code Climate](https://codeclimate.com/github/Midburn/Spark/badges/gpa.svg)](https://codeclimate.com/github/Midburn/Spark)
 [![Known Vulnerabilities](https://snyk.io/test/github/Midburn/Spark/badge.svg)](https://snyk.io/test/github/Midburn/Spark)
 [![Dependencies Status](https://david-dm.org/Midburn/Spark/status.svg)](https://david-dm.org/Midburn/Spark)


### PR DESCRIPTION
Self explainable. Travis projects urls are case sensitive.