### PR TITLE
Use Env. variable for volunteers module base URL.

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -143,7 +143,9 @@ let aws_config = {
     presignedUrlExpireSeconds: parseInt(process.env.SPARK_CAMP_FILES_PRESIGN_URL_EXPIRE_SECONDS)
 };
 exports.aws_config = aws_config
-
+exports.volunteers_config = {
+    api_url: process.env.VOLUNTEERS_BASE_URL || 'http://localhost:3500'
+}
 /**
  * Camp files config
  */

--- a/libs/volunteers.js
+++ b/libs/volunteers.js
@@ -1,6 +1,6 @@
 const request = require('superagent');
 const log = require('./logger.js')(module);
-const default_config = {api_url : 'http://localhost:3500'}
+const default_config = require('config').get('volunteers_config');
 const apiTokensConfig = require('config').get('api_tokens');
 const { URL } = require('url')
 


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
Volunteers module base url is hardcoded.
### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
Use environment variable to set base url.
### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->
None

### Testing Done
<!-- How have you confirmed this feature works? -->
Manual
<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Spark dependencies -->
<!-- 3. Make sure your code is compliant with the [Spark styleguide](CONTRIBUTING.md) -->
<!-- 4. If your PR fixes an issue, reference that issue -->
<!-- 5. If your PR has lots of commits, **rebase** first -->
<!-- 6. Run `npm test` before submitting your PR -->
