### PR TITLE
Link counter table to ticketing

### DIFF
--- a/libs/volunteers.js
+++ b/libs/volunteers.js
@@ -8,8 +8,8 @@ module.exports = function(config_ = undefined) {
     const config = config_ || default_config;
     let VOLUNTEERS_API_URL = config.api_url;
     const EARLY_ENTRY_URL = new URL('/api/v1/public/volunteers/getEarlyEntrance', VOLUNTEERS_API_URL);
-    return { 
-        
+    return {
+
         hasEarlyEntry: async userEmail => {
             try {
                 let response = await request
@@ -20,7 +20,7 @@ module.exports = function(config_ = undefined) {
                 return (!isNaN(early_arrival_time)) && early_arrival_time < Date.now();
             }
             catch (err) {
-                log.error(`Volunteers API hasEarlyEntry for ${email} failed. ${err}`)
+                log.error(`Volunteers API hasEarlyEntry for ${userEmail} failed. ${err}`)
                 return false;
             }
         },

--- a/routes/api/api_gate_routes.js
+++ b/routes/api/api_gate_routes.js
@@ -212,7 +212,7 @@ router.post('/gate-enter', async function (req, res) {
             }
             else if (!production_early_arrival)
             {
-                //return sendError(res, 500, "TICKET_NOT_IN_GROUP");
+                return sendError(res, 500, "TICKET_NOT_IN_GROUP");
             }
         }
     }

--- a/routes/api/api_gate_routes.js
+++ b/routes/api/api_gate_routes.js
@@ -125,7 +125,7 @@ router.post('/get-ticket/', async function (req, res) {
         let production_early_arrival = false;
         if (gate_status === 'early_arrival') {
             production_early_arrival = await volunteersAPI.hasEarlyEntry(holder.attributes.email);
-            log.debug(`get-ticket - user {holder.attributes.email} is a production volunteer`);
+            log.debug(`get-ticket - user ${holder.attributes.email} is a production volunteer`);
         }
         // Preparing result.
         let result = {
@@ -163,7 +163,7 @@ router.post('/gate-enter', async function (req, res) {
 
     // Loading ticket data from the DB.
     let [ticket, gate_status] = await getTicketBySearchTerms(req, res);
-
+    const isEarlyArrival = gate_status === "early_arrival";
     if (!ticket) {
         return sendError(res, 500, "TICKET_NOT_FOUND");
     }
@@ -187,7 +187,7 @@ router.post('/gate-enter', async function (req, res) {
         }
 
         let holder = ticket.relations.holder;
-        if (gate_status === "early_arrival")
+        if (isEarlyArrival)
         // Finding the right users group and updating it.
         {
             let production_early_arrival = false;
@@ -212,7 +212,7 @@ router.post('/gate-enter', async function (req, res) {
             }
             else if (!production_early_arrival)
             {
-                return sendError(res, 500, "TICKET_NOT_IN_GROUP");
+                //return sendError(res, 500, "TICKET_NOT_IN_GROUP");
             }
         }
     }
@@ -226,7 +226,12 @@ router.post('/gate-enter', async function (req, res) {
         ticket.attributes.first_entrance_timestamp = new Date();
     }
     await ticket.save();
-
+    // We want to add to the counter based on entry type (we don't use await to not break ticketing due to counter errors...)
+    const entryType = isEarlyArrival ? 'early_arrival' : 'regular';
+    knex(constants.ENTRIES_TABLE_NAME).insert({timestamp: new Date(), direction: 'arrival', event_id: req.body.event_id, type: entryType})
+        .catch(err => {
+            log.warn('A ticket entry count failed', err);
+        });
     // TODO PATCH - Notifying Drupal that this ticket is now non-transferable. Remove with Drupal.
     drupalSync.passTicket(ticket.attributes.barcode);
 
@@ -238,8 +243,8 @@ router.post('/gate-enter', async function (req, res) {
 router.post('/gate-exit', async function (req, res) {
 
     try {
-        let [ticket] = await getTicketBySearchTerms(req, res);
-
+        let [ticket, gate_status] = await getTicketBySearchTerms(req, res);
+        const isEarlyArrival = gate_status === "early_arrival";
         if (!ticket) {
             return sendError(res, 500, "TICKET_NOT_FOUND");
         }
@@ -258,7 +263,12 @@ router.post('/gate-exit', async function (req, res) {
         ticket.attributes.entrance_timestamp = null;
         ticket.attributes.last_exit_timestamp = new Date();
         await ticket.save();
-
+        // We want to add to the counter based on entry type (we don't use await to not break ticketing due to counter errors...)
+        const entryType = isEarlyArrival ? 'early_arrival' : 'regular';
+        knex(constants.ENTRIES_TABLE_NAME).insert({timestamp: new Date(), direction: 'departure', event_id: req.body.event_id, type: entryType})
+            .catch(err => {
+                log.warn('A ticket entry count failed', err);
+            });
         return res.status(200).json({
             message: "Ticket exit completed"
         });


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->

### Proposed solution
Fix volunteers api lib
Add to counter on gate enter + exit

### Testing Done
Commented usage of volunteers api (for the testing)
Ticketed (entry + exit) and watched counters.

### More

Reset won't change counter table, card for current people in event will change (uses ticket table)

![image](https://user-images.githubusercontent.com/24541325/39670815-6f670cea-5115-11e8-9f30-549002b27d15.png)

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 2. Run `npm install` to install all Spark dependencies -->
<!-- 3. Make sure your code is compliant with the [Spark styleguide](CONTRIBUTING.md) -->
<!-- 4. If your PR fixes an issue, reference that issue -->
<!-- 5. If your PR has lots of commits, **rebase** first -->
<!-- 6. Run `npm test` before submitting your PR -->
